### PR TITLE
Add local PatchLoop MVP prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# PatchLoop
+
+PatchLoop is a local prototype for collecting browser-based visual feedback on AI-generated demos and turning that feedback into structured issue context.
+
+## Run locally
+
+Open `index.html` in a browser, or serve the folder with any static file server.
+
+```sh
+python3 -m http.server 4173
+```
+
+Then visit `http://localhost:4173`.
+
+## What works now
+
+- Demo portal with owner, expiry, data classification, and feedback counts
+- Preview screen with feedback mode
+- Click-to-comment pins on the preview
+- Local feedback storage via `localStorage`
+- Dashboard with status triage
+- Generated GitHub Issue-style payload containing URL, position, selector, viewport, browser, branch, git SHA, logs, and AI instructions
+
+## Current boundary
+
+This first version does not call GitHub or store real screenshots on a backend. It creates local visual snapshots and mock Issue URLs so the product loop can be tested before adding auth, persistence, and integrations.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,449 @@
+const STORAGE_KEY = "patchloop.local.v1";
+
+const seedState = {
+  activeView: "portal",
+  selectedDemoId: "demo-1",
+  selectedFeedbackId: null,
+  statusFilter: "all",
+  demos: [
+    {
+      id: "demo-1",
+      title: "Revenue Ops Cockpit",
+      description: "営業・CS・経営が同じ画面を見て、パイプラインと更新リスクにコメントするための業務画面デモ。",
+      owner: "Kosako",
+      previewUrl: "http://localhost:3000/previews/revenue-ops",
+      repo: "kosako/revenue-ops-demo",
+      branch: "demo/revenue-cockpit",
+      gitSha: "8f42c9a",
+      status: "active",
+      dataClassification: "internal_dummy",
+      expiresAt: "2026-06-15",
+      createdAt: "2026-05-16T04:30:00.000Z"
+    },
+    {
+      id: "demo-2",
+      title: "Customer Risk Board",
+      description: "CS チーム向けに、解約リスクの検知と次アクションをレビューする試作。",
+      owner: "Product",
+      previewUrl: "http://localhost:3000/previews/customer-risk",
+      repo: "kosako/customer-risk-demo",
+      branch: "demo/risk-board",
+      gitSha: "c10a7db",
+      status: "active",
+      dataClassification: "public_dummy",
+      expiresAt: "2026-06-01",
+      createdAt: "2026-05-16T04:30:00.000Z"
+    }
+  ],
+  feedback: [
+    {
+      id: "fb-1",
+      demoId: "demo-1",
+      comment: "Expansion pipeline の増減理由を見られる導線がほしいです。",
+      author: "Kosako",
+      x: 42,
+      y: 56,
+      selector: ".sample-panel.wide",
+      pageUrl: "http://localhost:3000/previews/revenue-ops",
+      browser: "Local browser",
+      viewport: "1440x900",
+      status: "new",
+      issueUrl: "https://github.com/kosako/revenue-ops-demo/issues/new?title=PatchLoop%20feedback",
+      pullRequestUrl: "",
+      consoleLogs: ["info: preview loaded", "warn: using mock revenue data"],
+      networkErrors: [],
+      screenshot: "",
+      createdAt: "2026-05-16T04:35:00.000Z"
+    }
+  ]
+};
+
+let state = loadState();
+let feedbackMode = false;
+let pendingPoint = null;
+
+const viewTitles = {
+  portal: "Demo Portal",
+  preview: "Preview Feedback",
+  dashboard: "Feedback Dashboard"
+};
+
+const statuses = ["all", "new", "triaged", "ai-fix-candidate", "in-progress", "fixed", "rejected"];
+
+const $ = (selector) => document.querySelector(selector);
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return structuredClone(seedState);
+    return { ...structuredClone(seedState), ...JSON.parse(stored) };
+  } catch {
+    return structuredClone(seedState);
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function render() {
+  renderNavigation();
+  renderMetrics();
+  renderDemos();
+  renderDemoSelect();
+  renderPins();
+  renderStatusFilters();
+  renderFeedbackList();
+  renderDetail();
+  updatePreviewDemo();
+  saveState();
+}
+
+function renderNavigation() {
+  $("#viewTitle").textContent = viewTitles[state.activeView];
+  document.querySelectorAll(".view").forEach((view) => view.classList.remove("active"));
+  $(`#${state.activeView}View`).classList.add("active");
+  document.querySelectorAll(".nav-item").forEach((item) => {
+    item.classList.toggle("active", item.dataset.view === state.activeView);
+  });
+}
+
+function renderMetrics() {
+  const feedback = state.feedback;
+  $("#demoCount").textContent = state.demos.length;
+  $("#feedbackCount").textContent = feedback.length;
+  $("#candidateCount").textContent = feedback.filter((item) => item.status === "ai-fix-candidate").length;
+  $("#fixedCount").textContent = feedback.filter((item) => item.status === "fixed").length;
+}
+
+function renderDemos() {
+  $("#demoList").innerHTML = state.demos
+    .map((demo) => {
+      const count = state.feedback.filter((item) => item.demoId === demo.id).length;
+      return `
+        <article class="demo-card">
+          <div>
+            <h4>${escapeHtml(demo.title)}</h4>
+            <p>${escapeHtml(demo.description)}</p>
+          </div>
+          <div class="demo-meta">
+            <span class="pill">${escapeHtml(demo.owner)}</span>
+            <span class="pill">${escapeHtml(demo.dataClassification)}</span>
+            <span class="pill">${count} feedback</span>
+            <span class="pill">expires ${escapeHtml(demo.expiresAt)}</span>
+          </div>
+          <button class="secondary-button" data-open-demo="${demo.id}">Preview</button>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderDemoSelect() {
+  $("#demoSelect").innerHTML = state.demos
+    .map((demo) => `<option value="${demo.id}">${escapeHtml(demo.title)}</option>`)
+    .join("");
+  $("#demoSelect").value = state.selectedDemoId;
+}
+
+function renderPins() {
+  const pins = state.feedback.filter((item) => item.demoId === state.selectedDemoId);
+  $("#pinsLayer").innerHTML = pins
+    .map((item, index) => `<div class="pin" style="left:${item.x}%; top:${item.y}%">${index + 1}</div>`)
+    .join("");
+}
+
+function renderStatusFilters() {
+  $("#statusFilters").innerHTML = statuses
+    .map((status) => `<button class="status-button ${state.statusFilter === status ? "active" : ""}" data-status="${status}">${status}</button>`)
+    .join("");
+}
+
+function renderFeedbackList() {
+  const items = filteredFeedback();
+  $("#feedbackList").innerHTML = items.length
+    ? items
+        .map((item) => {
+          const demo = findDemo(item.demoId);
+          return `
+            <button class="feedback-item ${state.selectedFeedbackId === item.id ? "selected" : ""}" data-feedback="${item.id}">
+              <h4>${escapeHtml(item.comment)}</h4>
+              <div class="feedback-meta">
+                <span class="pill">${escapeHtml(item.status)}</span>
+                <span class="pill">${escapeHtml(demo?.title || "Unknown demo")}</span>
+                <span class="pill">${formatDate(item.createdAt)}</span>
+              </div>
+            </button>
+          `;
+        })
+        .join("")
+    : `<p class="empty-state">まだフィードバックはありません。</p>`;
+}
+
+function renderDetail() {
+  const item = state.feedback.find((feedback) => feedback.id === state.selectedFeedbackId) || filteredFeedback()[0];
+  if (!item) {
+    $("#detailPane").innerHTML = `<p class="empty-state">フィードバックを選ぶと、Issue 化に必要な文脈が表示されます。</p>`;
+    return;
+  }
+
+  state.selectedFeedbackId = item.id;
+  const demo = findDemo(item.demoId);
+  const issueBody = buildIssueBody(item, demo);
+  $("#detailPane").innerHTML = `
+    <h3>${escapeHtml(item.comment)}</h3>
+    <img class="snapshot" src="${item.screenshot || createSnapshot(item, demo)}" alt="Local visual snapshot" />
+    <div class="detail-list">
+      ${detailRow("Status", statusSelect(item))}
+      ${detailRow("Demo", demo?.title || "Unknown")}
+      ${detailRow("Author", item.author)}
+      ${detailRow("URL", item.pageUrl)}
+      ${detailRow("Position", `${item.x.toFixed(1)}%, ${item.y.toFixed(1)}%`)}
+      ${detailRow("Selector", item.selector)}
+      ${detailRow("Viewport", item.viewport)}
+      ${detailRow("Git", `${demo?.branch || ""} @ ${demo?.gitSha || ""}`)}
+      ${detailRow("Issue", `<a href="${item.issueUrl}" target="_blank" rel="noreferrer">mock issue link</a>`)}
+    </div>
+    <p class="panel-label">AI / GitHub Issue payload</p>
+    <div class="issue-box">${escapeHtml(issueBody)}</div>
+  `;
+}
+
+function detailRow(label, value) {
+  return `<div class="detail-row"><span>${escapeHtml(label)}</span><span>${value}</span></div>`;
+}
+
+function statusSelect(item) {
+  return `
+    <select data-status-update="${item.id}">
+      ${statuses
+        .filter((status) => status !== "all")
+        .map((status) => `<option value="${status}" ${item.status === status ? "selected" : ""}>${status}</option>`)
+        .join("")}
+    </select>
+  `;
+}
+
+function filteredFeedback() {
+  return state.feedback.filter((item) => state.statusFilter === "all" || item.status === state.statusFilter);
+}
+
+function findDemo(id) {
+  return state.demos.find((demo) => demo.id === id);
+}
+
+function updatePreviewDemo() {
+  const demo = findDemo(state.selectedDemoId);
+  if (!demo) return;
+  $("#sampleTitle").textContent = demo.title;
+  $(".sample-nav span").textContent = `Preview branch: ${demo.branch}`;
+}
+
+function openView(view) {
+  state.activeView = view;
+  render();
+}
+
+function createFeedback(point, comment, author) {
+  const demo = findDemo(state.selectedDemoId);
+  const item = {
+    id: `fb-${Date.now()}`,
+    demoId: demo.id,
+    comment,
+    author,
+    x: point.x,
+    y: point.y,
+    selector: point.selector,
+    pageUrl: demo.previewUrl,
+    browser: navigator.userAgent,
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    status: "new",
+    issueUrl: `https://github.com/${demo.repo}/issues/new?title=${encodeURIComponent(`[PatchLoop] ${comment.slice(0, 70)}`)}`,
+    pullRequestUrl: "",
+    consoleLogs: ["info: local PatchLoop prototype captured metadata"],
+    networkErrors: [],
+    screenshot: createSnapshot({ ...point, comment, author }, demo),
+    createdAt: new Date().toISOString()
+  };
+  state.feedback.unshift(item);
+  state.selectedFeedbackId = item.id;
+  state.activeView = "dashboard";
+  render();
+}
+
+function createSnapshot(item, demo) {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="960" height="600" viewBox="0 0 960 600">
+      <rect width="960" height="600" fill="#f7f8f5"/>
+      <rect x="38" y="38" width="884" height="524" rx="18" fill="#fff" stroke="#d9e1dd"/>
+      <rect x="38" y="38" width="884" height="86" rx="18" fill="#eef4f2"/>
+      <text x="72" y="91" font-family="Arial" font-size="28" font-weight="700" fill="#15201d">${escapeSvg(demo?.title || "PatchLoop demo")}</text>
+      <rect x="72" y="170" width="500" height="270" rx="12" fill="#e8f3ef"/>
+      <rect x="612" y="170" width="238" height="110" rx="12" fill="#fff3d6"/>
+      <rect x="612" y="310" width="238" height="130" rx="12" fill="#f8e4e8"/>
+      <circle cx="${38 + (item.x / 100) * 884}" cy="${38 + (item.y / 100) * 524}" r="18" fill="#d1495b" stroke="#fff" stroke-width="6"/>
+      <text x="72" y="506" font-family="Arial" font-size="20" fill="#15201d">${escapeSvg((item.comment || "").slice(0, 90))}</text>
+    </svg>
+  `;
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+function buildIssueBody(item, demo) {
+  return [
+    `## Feedback`,
+    item.comment,
+    ``,
+    `## Context`,
+    `- Demo: ${demo?.title}`,
+    `- URL: ${item.pageUrl}`,
+    `- Position: ${item.x.toFixed(1)}%, ${item.y.toFixed(1)}%`,
+    `- Selector: ${item.selector}`,
+    `- Browser: ${item.browser}`,
+    `- Viewport: ${item.viewport}`,
+    `- Branch: ${demo?.branch}`,
+    `- Git SHA: ${demo?.gitSha}`,
+    `- Data classification: ${demo?.dataClassification}`,
+    ``,
+    `## Logs`,
+    `Console: ${item.consoleLogs.join(", ") || "none"}`,
+    `Network errors: ${item.networkErrors.join(", ") || "none"}`,
+    ``,
+    `## AI instruction`,
+    `Reproduce the preview state, inspect the referenced area, propose a minimal UI or behavior fix, and open a PR. Do not auto-merge.`
+  ].join("\n");
+}
+
+function formatDate(value) {
+  return new Intl.DateTimeFormat("ja-JP", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }).format(new Date(value));
+}
+
+function escapeHtml(value = "") {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function escapeSvg(value = "") {
+  return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+document.addEventListener("click", (event) => {
+  const nav = event.target.closest("[data-view]");
+  if (nav) openView(nav.dataset.view);
+
+  const demoButton = event.target.closest("[data-open-demo]");
+  if (demoButton) {
+    state.selectedDemoId = demoButton.dataset.openDemo;
+    openView("preview");
+  }
+
+  const feedbackButton = event.target.closest("[data-feedback]");
+  if (feedbackButton) {
+    state.selectedFeedbackId = feedbackButton.dataset.feedback;
+    render();
+  }
+
+  const statusButton = event.target.closest("[data-status]");
+  if (statusButton) {
+    state.statusFilter = statusButton.dataset.status;
+    state.selectedFeedbackId = null;
+    render();
+  }
+});
+
+$("#openPreviewButton").addEventListener("click", () => openView("preview"));
+
+$("#feedbackModeButton").addEventListener("click", () => {
+  feedbackMode = !feedbackMode;
+  $("#feedbackModeButton").textContent = `Feedback mode: ${feedbackMode ? "ON" : "OFF"}`;
+  $(".preview-shell").classList.toggle("feedback-mode", feedbackMode);
+});
+
+$("#sampleApp").addEventListener("click", (event) => {
+  if (!feedbackMode) return;
+  const rect = $("#sampleApp").getBoundingClientRect();
+  pendingPoint = {
+    x: ((event.clientX - rect.left) / rect.width) * 100,
+    y: ((event.clientY - rect.top) / rect.height) * 100,
+    selector: selectorFor(event.target)
+  };
+  $("#commentInput").value = "";
+  $("#feedbackDialog").showModal();
+});
+
+$("#saveFeedbackButton").addEventListener("click", (event) => {
+  event.preventDefault();
+  const comment = $("#commentInput").value.trim();
+  const author = $("#authorInput").value.trim() || "Anonymous";
+  if (!comment || !pendingPoint) return;
+  $("#feedbackDialog").close();
+  feedbackMode = false;
+  $("#feedbackModeButton").textContent = "Feedback mode: OFF";
+  $(".preview-shell").classList.remove("feedback-mode");
+  createFeedback(pendingPoint, comment, author);
+  pendingPoint = null;
+});
+
+$("#newDemoButton").addEventListener("click", () => {
+  $("#demoTitleInput").value = "";
+  $("#demoDescriptionInput").value = "";
+  $("#demoOwnerInput").value = "Kosako";
+  $("#demoDialog").showModal();
+});
+
+$("#saveDemoButton").addEventListener("click", (event) => {
+  event.preventDefault();
+  const title = $("#demoTitleInput").value.trim();
+  if (!title) return;
+  const id = `demo-${Date.now()}`;
+  state.demos.unshift({
+    id,
+    title,
+    description: $("#demoDescriptionInput").value.trim() || "新しく追加されたローカルデモ。",
+    owner: $("#demoOwnerInput").value.trim() || "Unassigned",
+    previewUrl: `http://localhost:3000/previews/${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    repo: "kosako/patchloop-demo",
+    branch: "demo/local",
+    gitSha: Math.random().toString(16).slice(2, 9),
+    status: "active",
+    dataClassification: $("#demoClassificationInput").value,
+    expiresAt: "2026-06-30",
+    createdAt: new Date().toISOString()
+  });
+  state.selectedDemoId = id;
+  $("#demoDialog").close();
+  render();
+});
+
+$("#demoSelect").addEventListener("change", (event) => {
+  state.selectedDemoId = event.target.value;
+  render();
+});
+
+$("#resetButton").addEventListener("click", () => {
+  state = structuredClone(seedState);
+  render();
+});
+
+document.addEventListener("change", (event) => {
+  const select = event.target.closest("[data-status-update]");
+  if (!select) return;
+  const item = state.feedback.find((feedback) => feedback.id === select.dataset.statusUpdate);
+  if (item) {
+    item.status = select.value;
+    render();
+  }
+});
+
+function selectorFor(target) {
+  if (!target || target === document.body) return "body";
+  if (target.id) return `#${target.id}`;
+  const classes = Array.from(target.classList || []).slice(0, 2);
+  if (classes.length) return `${target.tagName.toLowerCase()}.${classes.join(".")}`;
+  return target.tagName.toLowerCase();
+}
+
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PatchLoop</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-mark">PL</div>
+          <div>
+            <h1>PatchLoop</h1>
+            <p>Demo feedback loop</p>
+          </div>
+        </div>
+
+        <nav class="nav" aria-label="Primary">
+          <button class="nav-item active" data-view="portal" title="Demo portal">
+            <span>⌂</span>
+            <span>Portal</span>
+          </button>
+          <button class="nav-item" data-view="preview" title="Preview and feedback widget">
+            <span>◎</span>
+            <span>Preview</span>
+          </button>
+          <button class="nav-item" data-view="dashboard" title="Feedback dashboard">
+            <span>☷</span>
+            <span>Dashboard</span>
+          </button>
+        </nav>
+
+        <div class="sidebar-panel">
+          <p class="panel-label">MVP loop</p>
+          <ol>
+            <li>Preview を触る</li>
+            <li>画面にコメント</li>
+            <li>Dashboard で triage</li>
+            <li>Issue 化の文脈を確認</li>
+          </ol>
+        </div>
+      </aside>
+
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="eyebrow">Local prototype</p>
+            <h2 id="viewTitle">Demo Portal</h2>
+          </div>
+          <div class="topbar-actions">
+            <button class="icon-button" id="resetButton" title="Reset local demo data">↺</button>
+            <button class="primary-button" id="openPreviewButton">Preview を開く</button>
+          </div>
+        </header>
+
+        <section class="view active" id="portalView" aria-labelledby="viewTitle">
+          <div class="summary-grid">
+            <article class="metric">
+              <span class="metric-label">Active demos</span>
+              <strong id="demoCount">0</strong>
+            </article>
+            <article class="metric">
+              <span class="metric-label">Feedback</span>
+              <strong id="feedbackCount">0</strong>
+            </article>
+            <article class="metric">
+              <span class="metric-label">AI candidates</span>
+              <strong id="candidateCount">0</strong>
+            </article>
+            <article class="metric">
+              <span class="metric-label">Fixed</span>
+              <strong id="fixedCount">0</strong>
+            </article>
+          </div>
+
+          <div class="section-heading">
+            <h3>Demos</h3>
+            <button class="secondary-button" id="newDemoButton">デモを追加</button>
+          </div>
+          <div class="demo-list" id="demoList"></div>
+        </section>
+
+        <section class="view" id="previewView" aria-labelledby="viewTitle">
+          <div class="preview-toolbar">
+            <label>
+              Demo
+              <select id="demoSelect"></select>
+            </label>
+            <button class="primary-button" id="feedbackModeButton">Feedback mode: OFF</button>
+          </div>
+
+          <div class="preview-shell">
+            <div class="sample-app" id="sampleApp">
+              <div class="sample-nav">
+                <strong id="sampleTitle">Revenue Ops Cockpit</strong>
+                <span>Preview branch: demo/revenue-cockpit</span>
+              </div>
+              <div class="sample-hero">
+                <div>
+                  <p class="eyebrow">Q2 operating view</p>
+                  <h3>Pipeline health and customer risk in one workspace.</h3>
+                </div>
+                <button>Export</button>
+              </div>
+              <div class="sample-grid">
+                <div class="sample-panel wide">
+                  <div class="panel-row">
+                    <span>Expansion pipeline</span>
+                    <strong>$2.4M</strong>
+                  </div>
+                  <div class="bar-chart">
+                    <span style="height: 46%"></span>
+                    <span style="height: 78%"></span>
+                    <span style="height: 58%"></span>
+                    <span style="height: 92%"></span>
+                    <span style="height: 66%"></span>
+                    <span style="height: 84%"></span>
+                  </div>
+                </div>
+                <div class="sample-panel">
+                  <div class="panel-row">
+                    <span>At-risk accounts</span>
+                    <strong>18</strong>
+                  </div>
+                  <ul class="risk-list">
+                    <li><span></span> Usage drop</li>
+                    <li><span></span> Renewal slip</li>
+                    <li><span></span> Missing owner</li>
+                  </ul>
+                </div>
+                <div class="sample-panel">
+                  <div class="panel-row">
+                    <span>Next review</span>
+                    <strong>May 21</strong>
+                  </div>
+                  <p class="muted">Comments in feedback mode are stored with URL, position, selector, viewport, browser, and a local visual snapshot.</p>
+                </div>
+              </div>
+            </div>
+            <div id="pinsLayer" class="pins-layer" aria-hidden="true"></div>
+          </div>
+        </section>
+
+        <section class="view" id="dashboardView" aria-labelledby="viewTitle">
+          <div class="dashboard-layout">
+            <div>
+              <div class="section-heading">
+                <h3>Feedback Inbox</h3>
+                <div class="filter-group" id="statusFilters"></div>
+              </div>
+              <div class="feedback-list" id="feedbackList"></div>
+            </div>
+            <aside class="detail-pane" id="detailPane">
+              <p class="empty-state">フィードバックを選ぶと、Issue 化に必要な文脈が表示されます。</p>
+            </aside>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <dialog id="feedbackDialog">
+      <form method="dialog" id="feedbackForm">
+        <header>
+          <h3>画面コメントを追加</h3>
+          <button value="cancel" class="icon-button" title="Close">×</button>
+        </header>
+        <label>
+          コメント
+          <textarea id="commentInput" rows="5" placeholder="例: このKPIの定義が分かる補足がほしい"></textarea>
+        </label>
+        <label>
+          投稿者
+          <input id="authorInput" value="Kosako" />
+        </label>
+        <menu>
+          <button value="cancel" class="secondary-button">キャンセル</button>
+          <button id="saveFeedbackButton" value="default" class="primary-button">保存</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="demoDialog">
+      <form method="dialog" id="demoForm">
+        <header>
+          <h3>デモを追加</h3>
+          <button value="cancel" class="icon-button" title="Close">×</button>
+        </header>
+        <label>
+          タイトル
+          <input id="demoTitleInput" placeholder="例: Billing workflow demo" />
+        </label>
+        <label>
+          説明
+          <textarea id="demoDescriptionInput" rows="3" placeholder="レビュー対象の概要"></textarea>
+        </label>
+        <div class="form-grid">
+          <label>
+            Owner
+            <input id="demoOwnerInput" placeholder="PdM" />
+          </label>
+          <label>
+            Data
+            <select id="demoClassificationInput">
+              <option>public_dummy</option>
+              <option>internal_dummy</option>
+              <option>internal_non_sensitive</option>
+              <option>restricted</option>
+              <option>prohibited</option>
+            </select>
+          </label>
+        </div>
+        <menu>
+          <button value="cancel" class="secondary-button">キャンセル</button>
+          <button id="saveDemoButton" value="default" class="primary-button">追加</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,569 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8f5;
+  --surface: #ffffff;
+  --surface-2: #eef4f2;
+  --ink: #15201d;
+  --muted: #65716d;
+  --line: #d9e1dd;
+  --accent: #0f7b63;
+  --accent-2: #d1495b;
+  --accent-3: #f2b84b;
+  --shadow: 0 18px 50px rgba(21, 32, 29, 0.1);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+#app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #13211d;
+  color: #f4faf7;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-mark {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  background: #c7f0df;
+  color: #10231d;
+  border-radius: 8px;
+  font-weight: 800;
+}
+
+.brand h1,
+.brand p,
+.topbar h2,
+.topbar p,
+.section-heading h3,
+.sample-hero h3 {
+  margin: 0;
+}
+
+.brand h1 {
+  font-size: 20px;
+}
+
+.brand p,
+.sidebar-panel,
+.muted {
+  color: #a9bbb4;
+}
+
+.nav {
+  display: grid;
+  gap: 8px;
+}
+
+.nav-item {
+  border: 0;
+  background: transparent;
+  color: #dce8e3;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  text-align: left;
+}
+
+.nav-item.active,
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.sidebar-panel {
+  margin-top: auto;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.panel-label,
+.eyebrow,
+.metric-label {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  font-weight: 700;
+}
+
+.sidebar-panel ol {
+  padding-left: 20px;
+  margin: 10px 0 0;
+}
+
+.main {
+  padding: 28px;
+  min-width: 0;
+}
+
+.topbar {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.topbar h2 {
+  font-size: 32px;
+}
+
+.topbar-actions,
+.section-heading,
+.preview-toolbar,
+.filter-group,
+.panel-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.primary-button,
+.secondary-button,
+.icon-button,
+.status-button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  min-height: 40px;
+  padding: 0 14px;
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.primary-button {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+}
+
+.icon-button {
+  width: 40px;
+  padding: 0;
+}
+
+.view {
+  display: none;
+}
+
+.view.active {
+  display: block;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 26px;
+}
+
+.metric,
+.demo-card,
+.feedback-item,
+.detail-pane,
+.sample-app,
+.sample-panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 1px 0 rgba(21, 32, 29, 0.03);
+}
+
+.metric {
+  padding: 18px;
+}
+
+.metric strong {
+  display: block;
+  font-size: 34px;
+  margin-top: 8px;
+}
+
+.section-heading {
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.demo-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.demo-card {
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.demo-card h4,
+.feedback-item h4,
+.detail-pane h3 {
+  margin: 0;
+}
+
+.demo-meta,
+.feedback-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: #2d4640;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.preview-toolbar {
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.preview-toolbar label,
+dialog label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+select,
+input,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--ink);
+  padding: 10px 12px;
+}
+
+.preview-shell {
+  position: relative;
+  border-radius: 8px;
+}
+
+.sample-app {
+  min-height: 620px;
+  overflow: hidden;
+}
+
+.sample-nav {
+  height: 58px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 22px;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+}
+
+.sample-nav strong {
+  color: var(--ink);
+}
+
+.sample-hero {
+  min-height: 190px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 28px;
+  background:
+    linear-gradient(90deg, rgba(15, 123, 99, 0.12), rgba(242, 184, 75, 0.18)),
+    #f8fbfa;
+}
+
+.sample-hero h3 {
+  max-width: 700px;
+  font-size: 38px;
+  line-height: 1.08;
+}
+
+.sample-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 16px;
+  padding: 18px;
+}
+
+.sample-panel {
+  min-height: 180px;
+  padding: 18px;
+}
+
+.sample-panel.wide {
+  grid-row: span 2;
+}
+
+.panel-row {
+  justify-content: space-between;
+}
+
+.bar-chart {
+  height: 280px;
+  display: flex;
+  align-items: end;
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.bar-chart span {
+  flex: 1;
+  min-width: 28px;
+  border-radius: 6px 6px 0 0;
+  background: var(--accent);
+}
+
+.bar-chart span:nth-child(even) {
+  background: var(--accent-3);
+}
+
+.risk-list {
+  display: grid;
+  gap: 12px;
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.risk-list span {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent-2);
+  margin-right: 8px;
+}
+
+.pins-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.pin {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  transform: translate(-50%, -50%);
+  border: 3px solid #fff;
+  border-radius: 50%;
+  background: var(--accent-2);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 800;
+  box-shadow: var(--shadow);
+}
+
+.feedback-mode .sample-app {
+  outline: 3px solid rgba(209, 73, 91, 0.45);
+  cursor: crosshair;
+}
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 390px;
+  gap: 16px;
+  align-items: start;
+}
+
+.feedback-list {
+  display: grid;
+  gap: 10px;
+}
+
+.feedback-item {
+  width: 100%;
+  text-align: left;
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.feedback-item.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(15, 123, 99, 0.14);
+}
+
+.status-button.active {
+  background: #13211d;
+  color: #fff;
+}
+
+.detail-pane {
+  min-height: 520px;
+  padding: 18px;
+  position: sticky;
+  top: 20px;
+}
+
+.snapshot {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  margin: 14px 0;
+  background: var(--surface-2);
+}
+
+.detail-list {
+  display: grid;
+  gap: 10px;
+  margin: 14px 0;
+}
+
+.detail-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.detail-row span:first-child {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.issue-box {
+  background: #f5f7f6;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.empty-state {
+  color: var(--muted);
+  margin: 0;
+}
+
+dialog {
+  border: 0;
+  border-radius: 8px;
+  padding: 0;
+  box-shadow: var(--shadow);
+  width: min(520px, calc(100vw - 28px));
+}
+
+dialog::backdrop {
+  background: rgba(19, 33, 29, 0.42);
+}
+
+dialog form {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+}
+
+dialog header,
+dialog menu {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 980px) {
+  #app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .summary-grid,
+  .demo-list,
+  .dashboard-layout,
+  .sample-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .main,
+  .sidebar {
+    padding: 18px;
+  }
+
+  .topbar,
+  .sample-nav,
+  .sample-hero,
+  .preview-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .topbar h2,
+  .sample-hero h3 {
+    font-size: 28px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a dependency-free local PatchLoop MVP prototype
- Includes Demo Portal, Preview feedback mode, and Feedback Dashboard views
- Stores prototype data in localStorage and generates GitHub Issue-style context payloads
- Documents local run instructions and current integration boundaries

## Verification
- Served the static prototype with Python SimpleHTTPServer and confirmed HTTP 200 for the HTML
- Ran 
- Attempted in-app browser verification, but local file and localhost navigation were blocked by the browser environment policy/client

Closes #1