### PR TITLE
Widget の操作感を整え、範囲選択コメントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # PatchLoop
 
-PatchLoop is a local prototype for collecting browser-based visual feedback on AI-generated demos and turning that feedback into structured issue context.
+PatchLoop は、AI で作った demo / PoC に対してブラウザ上で直接フィードバックを残し、その内容を Slack / GitHub / AI 修正 PR につなげるための実験的プロトタイプです。
 
-## Run locally
+PatchLoop is an experimental prototype for collecting browser-based visual feedback on AI-generated demos and turning that feedback into Slack, GitHub, or AI repair context.
 
-Open `index.html` in a browser, or serve the folder with any static file server.
+## ローカルで起動する / Run Locally
+
+`index.html` を直接ブラウザで開くか、任意の静的ファイルサーバーで配信します。
+
+Open `index.html` directly in a browser, or serve the folder with any static file server.
 
 ```sh
 python3 -m http.server 4173
 ```
 
-Then visit `http://localhost:4173`.
+その後、以下を開きます。
 
-The embeddable widget example is available at:
+Then visit:
+
+```text
+http://localhost:4173
+```
+
+script-tag widget の例はこちらです。
+
+The script-tag widget example is available at:
+
 
 ```text
 http://localhost:4173/examples/plain-html/
 ```
 
-## What works now
+## 現在できること / What Works Now
+
+ローカル prototype:
 
 - Demo portal with owner, expiry, data classification, and feedback counts
 - Preview screen with feedback mode
@@ -27,9 +42,22 @@ http://localhost:4173/examples/plain-html/
 - Dashboard with status triage
 - Generated GitHub Issue-style payload containing URL, position, selector, viewport, browser, branch, git SHA, logs, and AI instructions
 
-## Embeddable widget
+script-tag widget:
 
-PatchLoop now includes a standalone script-tag widget:
+- Floating feedback launcher
+- Comment mode toggle
+- Click-to-pin location capture
+- Drag-to-select area capture
+- Comment form
+- Payload generation with URL, point/area position, selector, viewport, browser, reviewer, and timestamp
+- Optional `onSubmit(payload)` callback
+- Optional `endpoint` setting for a future POST receiver
+
+## 埋め込み Widget / Embeddable Widget
+
+PatchLoop は、普通の HTML に `script` tag で埋め込める standalone widget を含んでいます。
+
+PatchLoop includes a standalone widget that can be embedded into a normal HTML page with a `script` tag.
 
 ```html
 <script src="../../widget/patchloop-widget.js"></script>
@@ -45,16 +73,61 @@ PatchLoop now includes a standalone script-tag widget:
 </script>
 ```
 
-The first widget slice supports:
+基本操作:
 
-- Floating feedback launcher
-- Comment mode toggle
-- Click-to-pin location capture
-- Comment form
-- Payload generation with URL, x/y position, selector, viewport, browser, reviewer, and timestamp
-- Optional `onSubmit(payload)` callback
-- Optional `endpoint` setting for a future POST receiver
+1. 右下の「フィードバック」を押す
+2. 「コメントモード開始」を押す
+3. 画面上の場所をクリック、または範囲をドラッグする
+4. コメントを書いて送信する
+5. `onSubmit(payload)` で payload を受け取る
 
-## Current boundary
+Basic flow:
 
-This version does not call GitHub, Slack, or a backend. It creates local visual snapshots and feedback payloads so the product loop can be tested before adding delivery adapters, auth, persistence, and integrations.
+1. Click the feedback launcher
+2. Start comment mode
+3. Click a point or drag an area on the page
+4. Write and submit a comment
+5. Receive the payload through `onSubmit(payload)`
+
+## Payload
+
+主な payload 項目:
+
+Main payload fields:
+
+- `projectId`
+- `demoId`
+- `comment`
+- `reviewer`
+- `page.url`
+- `page.title`
+- `target.kind`
+- `target.x`
+- `target.y`
+- `target.area`
+- `target.selector`
+- `target.text`
+- `environment.viewport`
+- `environment.browser`
+- `createdAt`
+
+`target.kind` は `point` または `area` です。範囲選択の場合は `target.area` に `x`, `y`, `width`, `height` が percentage で入ります。
+
+`target.kind` is either `point` or `area`. For area selections, `target.area` includes `x`, `y`, `width`, and `height` as percentages.
+
+## 現在の境界 / Current Boundary
+
+このバージョンは、まだ GitHub / Slack / backend には送信しません。まずは script-tag widget の操作感と payload の形を検証する段階です。
+
+This version does not send data to GitHub, Slack, or a backend yet. The current focus is validating the script-tag widget interaction and payload shape.
+
+未対応:
+
+Not included yet:
+
+- GitHub Issue 作成 / GitHub Issue creation
+- Slack 投稿 / Slack delivery
+- backend persistence
+- 本物の screenshot capture / real screenshot capture
+- 認証 / auth
+- AI PR 連携 / AI PR integration

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -3,27 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PatchLoop Plain HTML Example</title>
+    <title>PatchLoop プレーンHTML例</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <header class="app-header">
       <div>
-        <p class="eyebrow">Plain HTML preview</p>
-        <h1>Customer Renewal Review</h1>
+        <p class="eyebrow">プレーンHTMLプレビュー</p>
+        <h1>顧客更新レビュー</h1>
       </div>
-      <button>Share preview</button>
+      <button>プレビュー共有</button>
     </header>
 
     <main>
       <section class="hero">
         <div>
-          <p class="eyebrow">Workspace</p>
-          <h2>Review account health before the weekly pipeline meeting.</h2>
-          <p class="lede">This page has no build step. PatchLoop is added by one script tag and initialized with a few options.</p>
+          <p class="eyebrow">レビュー画面</p>
+          <h2>週次パイプライン会議の前に、顧客の健全性を確認する。</h2>
+          <p class="lede">このページにはビルド手順がありません。PatchLoop は script tag と数行の設定だけで追加されています。</p>
         </div>
         <aside class="score-card">
-          <span>Renewal confidence</span>
+          <span>更新確度</span>
           <strong>74%</strong>
         </aside>
       </section>
@@ -31,7 +31,7 @@
       <section class="grid">
         <article class="panel wide">
           <div class="panel-title">
-            <h3>Expansion pipeline</h3>
+            <h3>拡張パイプライン</h3>
             <strong>$2.4M</strong>
           </div>
           <div class="bars" aria-label="Pipeline bar chart">
@@ -46,31 +46,31 @@
 
         <article class="panel">
           <div class="panel-title">
-            <h3>At-risk accounts</h3>
+            <h3>リスク顧客</h3>
             <strong>18</strong>
           </div>
           <ul class="risk-list">
-            <li><span class="risk high"></span> Usage dropped this week</li>
-            <li><span class="risk medium"></span> Renewal owner missing</li>
-            <li><span class="risk low"></span> Legal review pending</li>
+            <li><span class="risk high"></span> 今週の利用量が低下</li>
+            <li><span class="risk medium"></span> 更新担当者が未設定</li>
+            <li><span class="risk low"></span> 法務レビュー待ち</li>
           </ul>
         </article>
 
         <article class="panel">
           <div class="panel-title">
-            <h3>Next actions</h3>
+            <h3>次のアクション</h3>
             <strong>6</strong>
           </div>
-          <p>Click any precise area with PatchLoop feedback mode to create a location-aware comment payload.</p>
+          <p>PatchLoop のコメントモードで画面上の場所をクリック、または範囲をドラッグすると、位置情報付きのコメント payload が作られます。</p>
         </article>
       </section>
 
       <section class="payload-log">
         <div>
-          <p class="eyebrow">Latest widget payload</p>
-          <h3>Captured feedback appears here</h3>
+          <p class="eyebrow">最新の widget payload</p>
+          <h3>送信したフィードバックがここに表示されます</h3>
         </div>
-        <pre id="payloadOutput">No feedback submitted yet.</pre>
+        <pre id="payloadOutput">まだフィードバックはありません。</pre>
       </section>
     </main>
 

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -14,6 +14,8 @@
     options: { ...DEFAULTS },
     active: false,
     pendingTarget: null,
+    drag: null,
+    suppressNextClick: false,
     feedback: []
   };
 
@@ -26,11 +28,17 @@
   }
 
   function destroy() {
-    document.removeEventListener("click", handleDocumentClick, true);
+    document.removeEventListener("mousedown", handleDocumentMouseDown, true);
+    document.removeEventListener("mousemove", handleDocumentMouseMove, true);
+    document.removeEventListener("mouseup", handleDocumentMouseUp, true);
+    document.removeEventListener("click", suppressDocumentClick, true);
     document.querySelector("[data-patchloop-root]")?.remove();
     document.querySelectorAll("[data-patchloop-pin]").forEach((node) => node.remove());
+    document.querySelectorAll("[data-patchloop-area]").forEach((node) => node.remove());
+    removeSelectionBox();
     state.active = false;
     state.pendingTarget = null;
+    state.drag = null;
   }
 
   function renderShell() {
@@ -42,32 +50,32 @@
     root.innerHTML = `
       <button class="pl-launcher" type="button" data-pl-toggle aria-pressed="false" title="Toggle PatchLoop feedback mode">
         <span class="pl-dot"></span>
-        <span>Feedback</span>
+        <span>フィードバック</span>
       </button>
       <section class="pl-panel" data-pl-panel hidden>
         <header>
           <strong>PatchLoop</strong>
-          <button type="button" data-pl-close title="Close">x</button>
+          <button type="button" data-pl-close title="閉じる">x</button>
         </header>
-        <p data-pl-help>Turn feedback mode on, then click the page.</p>
+        <p data-pl-help>コメントモードを開始して、画面上の気になる場所をクリックしてください。</p>
         <div class="pl-actions">
-          <button type="button" data-pl-mode>Start comment mode</button>
-          <button type="button" data-pl-clear>Clear pins</button>
+          <button type="button" data-pl-mode>コメントモード開始</button>
+          <button type="button" data-pl-clear>ピンを消す</button>
         </div>
-        <div class="pl-payload" data-pl-payload>No feedback yet.</div>
+        <div class="pl-payload" data-pl-payload>まだフィードバックはありません。</div>
       </section>
       <form class="pl-comment" data-pl-comment hidden>
         <label>
-          Comment
-          <textarea data-pl-comment-text rows="4" placeholder="What should change here?"></textarea>
+          コメント
+          <textarea data-pl-comment-text rows="4" placeholder="ここで何を直したいですか？"></textarea>
         </label>
         <label>
-          Reviewer
-          <input data-pl-reviewer value="${escapeHtml(state.options.reviewer)}" placeholder="Your name" />
+          投稿者
+          <input data-pl-reviewer value="${escapeHtml(state.options.reviewer)}" placeholder="名前" />
         </label>
         <div class="pl-form-actions">
-          <button type="button" data-pl-cancel>Cancel</button>
-          <button type="submit">Submit</button>
+          <button type="button" data-pl-cancel>キャンセル</button>
+          <button type="submit">送信</button>
         </div>
       </form>
     `;
@@ -83,27 +91,101 @@
   }
 
   function bindGlobalCapture() {
-    document.removeEventListener("click", handleDocumentClick, true);
-    document.addEventListener("click", handleDocumentClick, true);
+    document.removeEventListener("mousedown", handleDocumentMouseDown, true);
+    document.removeEventListener("mousemove", handleDocumentMouseMove, true);
+    document.removeEventListener("mouseup", handleDocumentMouseUp, true);
+    document.removeEventListener("click", suppressDocumentClick, true);
+    document.addEventListener("mousedown", handleDocumentMouseDown, true);
+    document.addEventListener("mousemove", handleDocumentMouseMove, true);
+    document.addEventListener("mouseup", handleDocumentMouseUp, true);
+    document.addEventListener("click", suppressDocumentClick, true);
   }
 
-  function handleDocumentClick(event) {
+  function handleDocumentMouseDown(event) {
     if (!state.active) return;
     if (event.target.closest("[data-patchloop-root]")) return;
 
     event.preventDefault();
     event.stopPropagation();
 
-    const target = event.target;
-    const point = pointFromEvent(event);
-    state.pendingTarget = {
-      ...point,
-      selector: selectorFor(target),
-      elementText: textFor(target)
+    state.drag = {
+      startedAt: pointFromEvent(event),
+      latest: pointFromEvent(event),
+      target: event.target,
+      isDragging: false
     };
+    state.suppressNextClick = true;
+  }
 
-    addPin(point);
-    openCommentForm(point);
+  function handleDocumentMouseMove(event) {
+    if (!state.active || !state.drag) return;
+    if (event.target.closest("[data-patchloop-root]")) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    state.drag.latest = pointFromEvent(event);
+    const rect = rectFromPoints(state.drag.startedAt, state.drag.latest);
+    state.drag.isDragging = rect.widthPx > 8 || rect.heightPx > 8;
+
+    if (state.drag.isDragging) {
+      renderSelectionBox(rect);
+    }
+  }
+
+  function handleDocumentMouseUp(event) {
+    if (!state.active || !state.drag) return;
+    if (event.target.closest("[data-patchloop-root]")) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const start = state.drag.startedAt;
+    const end = pointFromEvent(event);
+    const rect = rectFromPoints(start, end);
+    const target = document.elementFromPoint(start.clientX, start.clientY) || state.drag.target;
+
+    if (state.drag.isDragging) {
+      state.pendingTarget = {
+        kind: "area",
+        ...pointFromClient(rect.leftPx, rect.topPx),
+        area: {
+          x: round(rect.x),
+          y: round(rect.y),
+          width: round(rect.width),
+          height: round(rect.height),
+          clientX: Math.round(rect.leftPx),
+          clientY: Math.round(rect.topPx),
+          clientWidth: Math.round(rect.widthPx),
+          clientHeight: Math.round(rect.heightPx)
+        },
+        selector: selectorFor(target),
+        elementText: textFor(target)
+      };
+      addArea(rect);
+      openCommentForm({ clientX: rect.rightPx, clientY: rect.bottomPx });
+    } else {
+      const point = pointFromEvent(event);
+      state.pendingTarget = {
+        kind: "point",
+        ...point,
+        selector: selectorFor(target),
+        elementText: textFor(target)
+      };
+      addPin(point);
+      openCommentForm(point);
+    }
+
+    removeSelectionBox();
+    state.drag = null;
+  }
+
+  function suppressDocumentClick(event) {
+    if (!state.suppressNextClick) return;
+    state.suppressNextClick = false;
+    if (event.target.closest("[data-patchloop-root]")) return;
+    event.preventDefault();
+    event.stopPropagation();
   }
 
   function togglePanel() {
@@ -124,8 +206,12 @@
     document.documentElement.classList.toggle("pl-feedback-active", state.active);
     const root = getRoot();
     root.querySelector("[data-pl-toggle]").setAttribute("aria-pressed", String(state.active));
-    root.querySelector("[data-pl-mode]").textContent = state.active ? "Stop comment mode" : "Start comment mode";
-    root.querySelector("[data-pl-help]").textContent = state.active ? "Click the exact place that needs feedback." : "Turn feedback mode on, then click the page.";
+    root.querySelector("[data-pl-mode]").textContent = state.active ? "コメントモード終了" : "コメントモード開始";
+    root.querySelector("[data-pl-help]").textContent = state.active ? "点をクリック、または範囲をドラッグしてコメントできます。" : "コメントモードを開始して、画面上の気になる場所をクリックしてください。";
+    if (!state.active) {
+      removeSelectionBox();
+      state.drag = null;
+    }
   }
 
   function openCommentForm(point) {
@@ -180,10 +266,12 @@
         title: document.title
       },
       target: {
+        kind: target.kind || "point",
         x: round(target.x),
         y: round(target.y),
         clientX: Math.round(target.clientX),
         clientY: Math.round(target.clientY),
+        area: target.area || null,
         selector: target.selector,
         text: target.elementText
       },
@@ -233,17 +321,79 @@
 
   function clearPins() {
     document.querySelectorAll("[data-patchloop-pin]").forEach((node) => node.remove());
+    document.querySelectorAll("[data-patchloop-area]").forEach((node) => node.remove());
+    removeSelectionBox();
     state.feedback = [];
-    getRoot().querySelector("[data-pl-payload]").textContent = "No feedback yet.";
+    getRoot().querySelector("[data-pl-payload]").textContent = "まだフィードバックはありません。";
   }
 
   function pointFromEvent(event) {
+    return pointFromClient(event.clientX, event.clientY);
+  }
+
+  function pointFromClient(clientX, clientY) {
     return {
-      x: (event.clientX / Math.max(document.documentElement.clientWidth, 1)) * 100,
-      y: (event.clientY / Math.max(document.documentElement.clientHeight, 1)) * 100,
-      clientX: event.clientX,
-      clientY: event.clientY
+      x: (clientX / Math.max(document.documentElement.clientWidth, 1)) * 100,
+      y: (clientY / Math.max(document.documentElement.clientHeight, 1)) * 100,
+      clientX,
+      clientY
     };
+  }
+
+  function rectFromPoints(start, end) {
+    const leftPx = Math.min(start.clientX, end.clientX);
+    const topPx = Math.min(start.clientY, end.clientY);
+    const rightPx = Math.max(start.clientX, end.clientX);
+    const bottomPx = Math.max(start.clientY, end.clientY);
+    const viewportWidth = Math.max(document.documentElement.clientWidth, 1);
+    const viewportHeight = Math.max(document.documentElement.clientHeight, 1);
+
+    return {
+      leftPx,
+      topPx,
+      rightPx,
+      bottomPx,
+      widthPx: rightPx - leftPx,
+      heightPx: bottomPx - topPx,
+      x: (leftPx / viewportWidth) * 100,
+      y: (topPx / viewportHeight) * 100,
+      width: ((rightPx - leftPx) / viewportWidth) * 100,
+      height: ((bottomPx - topPx) / viewportHeight) * 100
+    };
+  }
+
+  function renderSelectionBox(rect) {
+    let box = document.querySelector("[data-patchloop-selection]");
+    if (!box) {
+      box = document.createElement("div");
+      box.dataset.patchloopSelection = "true";
+      box.className = "pl-selection";
+      document.body.append(box);
+    }
+    Object.assign(box.style, {
+      left: `${rect.leftPx}px`,
+      top: `${rect.topPx}px`,
+      width: `${rect.widthPx}px`,
+      height: `${rect.heightPx}px`
+    });
+  }
+
+  function removeSelectionBox() {
+    document.querySelector("[data-patchloop-selection]")?.remove();
+  }
+
+  function addArea(rect) {
+    const area = document.createElement("div");
+    area.dataset.patchloopArea = "true";
+    area.className = "pl-area";
+    Object.assign(area.style, {
+      left: `${rect.leftPx}px`,
+      top: `${rect.topPx}px`,
+      width: `${rect.widthPx}px`,
+      height: `${rect.heightPx}px`
+    });
+    area.innerHTML = `<span>${state.feedback.length + 1}</span>`;
+    document.body.append(area);
   }
 
   function selectorFor(element) {
@@ -298,6 +448,7 @@
     style.dataset.patchloopStyle = "true";
     style.textContent = `
       .pl-root, .pl-root * { box-sizing: border-box; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .pl-root [hidden], .pl-comment[hidden], .pl-panel[hidden] { display: none !important; }
       .pl-root { position: fixed; z-index: 2147483000; color: #14211d; }
       .pl-bottom-right { right: 20px; bottom: 20px; }
       .pl-launcher { min-height: 42px; border: 1px solid #0f7b63; border-radius: 999px; padding: 0 16px; display: inline-flex; align-items: center; gap: 8px; background: #0f7b63; color: #fff; font-weight: 800; box-shadow: 0 16px 40px rgba(20, 33, 29, 0.18); cursor: pointer; }
@@ -316,6 +467,9 @@
       .pl-comment textarea, .pl-comment input { width: 100%; border: 1px solid #d9e1dd; border-radius: 8px; padding: 9px 10px; color: #14211d; font: inherit; resize: vertical; }
       .pl-form-actions { display: flex; justify-content: flex-end; gap: 8px; }
       .pl-pin { position: fixed; z-index: 2147482999; transform: translate(-50%, -50%); width: 30px; height: 30px; border-radius: 50%; border: 3px solid #fff; background: #d1495b; color: #fff; font-weight: 900; box-shadow: 0 12px 30px rgba(20, 33, 29, 0.25); pointer-events: none; }
+      .pl-selection, .pl-area { position: fixed; z-index: 2147482998; border: 2px solid #d1495b; background: rgba(209, 73, 91, 0.12); border-radius: 6px; pointer-events: none; }
+      .pl-area { box-shadow: 0 12px 30px rgba(20, 33, 29, 0.16); }
+      .pl-area span { position: absolute; top: -15px; left: -15px; width: 30px; height: 30px; display: grid; place-items: center; border-radius: 50%; border: 3px solid #fff; background: #d1495b; color: #fff; font-weight: 900; box-shadow: 0 12px 30px rgba(20, 33, 29, 0.25); }
       .pl-feedback-active, .pl-feedback-active * { cursor: crosshair !important; }
     `;
     document.head.append(style);


### PR DESCRIPTION
## 概要
- Widget UI と plain HTML example を日本語化
- README を日本語 / English の併記に更新
- コメント送信後にフォームが消えない問題を修正
- クリックによる point comment に加えて、ドラッグによる area comment を追加
- payload に target.kind と target.area を追加

## 確認したこと
- node --check widget/patchloop-widget.js
- local static server で examples/plain-html/ が HTTP 200 を返すこと
- in-app browser で日本語表示と widget root の注入を確認

## 補足
ブラウザ自動操作ではテキスト入力まわりに制約があり、フォーム送信の完全自動確認はできていません。ローカルブラウザでの手動確認を推奨します。

Closes #5