### PR TITLE
feat: add local feedback receiver and inbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+server/feedback.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -125,19 +125,43 @@ Main payload fields:
 
 `clientX/clientY` represent viewport coordinates, while `pageX/pageY` represent document coordinates including scroll. Pins and area overlays are anchored to document coordinates so they stay attached to the target while scrolling.
 
+## ローカル receiver / Local Receiver
+
+`endpoint` を指定すると、widget は payload をその URL に POST します。検証用のローカル receiver が同梱されています。
+
+When `endpoint` is set, the widget POSTs the payload to that URL. A local receiver is bundled for testing.
+
+```sh
+node server/receive.js
+```
+
+- `POST /feedback` で payload を受け取り、`server/feedback.json` に追記します
+- `GET /` で受信した feedback の一覧（inbox）を表示します
+- `GET /feedback.json` で raw JSON を返します
+- `PORT` / `HOST` env で変更可能（デフォルトは `127.0.0.1:4000`）
+
+- Accepts payload at `POST /feedback`, appends to `server/feedback.json`
+- Renders an inbox of received feedback at `GET /`
+- Returns the raw JSON at `GET /feedback.json`
+- Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
+
+`examples/plain-html/` はデフォルトで `http://localhost:4000/feedback` に送信する設定です。`python3 -m http.server 4173` でページを配信した状態で receiver も起動すると、コメントが inbox に届きます。
+
+`examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
+
 ## 現在の境界 / Current Boundary
 
-このバージョンは、まだ GitHub / Slack / backend には送信しません。まずは script-tag widget の操作感と payload の形を検証する段階です。
+このバージョンは、まだ GitHub / Slack には直接送信しません。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。
 
-This version does not send data to GitHub, Slack, or a backend yet. The current focus is validating the script-tag widget interaction and payload shape.
+This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver.
 
 未対応:
 
 Not included yet:
 
-- GitHub Issue 作成 / GitHub Issue creation
 - Slack 投稿 / Slack delivery
-- backend persistence
+- GitHub Issue 作成 / GitHub Issue creation
+- 永続 DB / persistent database
 - 本物の screenshot capture / real screenshot capture
 - 認証 / auth
 - AI PR 連携 / AI PR integration

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -80,6 +80,7 @@
         projectId: "patchloop",
         demoId: "plain-html-renewal-review",
         reviewer: "Kosako",
+        endpoint: "http://localhost:4000/feedback",
         onSubmit(payload) {
           document.querySelector("#payloadOutput").textContent = JSON.stringify(payload, null, 2);
         }

--- a/server/receive.js
+++ b/server/receive.js
@@ -1,0 +1,205 @@
+"use strict";
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const PORT = Number(process.env.PORT || 4000);
+const HOST = process.env.HOST || "127.0.0.1";
+const STORE_PATH = path.join(__dirname, "feedback.json");
+const MAX_BODY_BYTES = 1_000_000;
+
+let feedback = loadFeedback();
+
+const server = http.createServer((req, res) => {
+  setCors(res);
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/feedback") {
+    handlePostFeedback(req, res);
+    return;
+  }
+
+  if (req.method === "GET" && (req.url === "/" || req.url === "/index.html")) {
+    handleGetInbox(req, res);
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/feedback.json") {
+    respondJson(res, 200, feedback);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end("Not Found");
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[PatchLoop receiver] listening on http://${HOST}:${PORT}`);
+  console.log(`[PatchLoop receiver] feedback file: ${STORE_PATH}`);
+});
+
+function setCors(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+}
+
+function handlePostFeedback(req, res) {
+  let received = 0;
+  const chunks = [];
+  let aborted = false;
+
+  req.on("data", (chunk) => {
+    if (aborted) return;
+    received += chunk.length;
+    if (received > MAX_BODY_BYTES) {
+      aborted = true;
+      respondJson(res, 413, { ok: false, error: "Payload too large" });
+      req.destroy();
+      return;
+    }
+    chunks.push(chunk);
+  });
+
+  req.on("end", () => {
+    if (aborted) return;
+    let payload;
+    try {
+      payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    } catch (_) {
+      respondJson(res, 400, { ok: false, error: "Invalid JSON" });
+      return;
+    }
+    const stored = { receivedAt: new Date().toISOString(), ...payload };
+    feedback.unshift(stored);
+    persist();
+    console.log(`[PatchLoop receiver] received feedback id=${payload?.id || "?"} comment="${truncate(payload?.comment || "", 60)}"`);
+    respondJson(res, 201, { ok: true, id: payload?.id, count: feedback.length });
+  });
+
+  req.on("error", (error) => {
+    if (aborted) return;
+    respondJson(res, 500, { ok: false, error: error.message });
+  });
+}
+
+function handleGetInbox(req, res) {
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(renderInbox(feedback));
+}
+
+function loadFeedback() {
+  try {
+    const raw = fs.readFileSync(STORE_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function persist() {
+  fs.writeFileSync(STORE_PATH, JSON.stringify(feedback, null, 2));
+}
+
+function respondJson(res, status, body) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function truncate(value, max) {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function renderInbox(items) {
+  const cards = items.map((item) => {
+    const target = item.target || {};
+    const env = item.environment || {};
+    const page = item.page || {};
+    const kind = escapeHtml(target.kind || "?");
+    const selector = escapeHtml(target.selector || "");
+    const pageUrl = escapeHtml(page.url || "");
+    const pageTitle = escapeHtml(page.title || "");
+    const comment = escapeHtml(item.comment || "");
+    const reviewer = escapeHtml(item.reviewer || "");
+    const createdAt = escapeHtml(item.createdAt || "");
+    const receivedAt = escapeHtml(item.receivedAt || "");
+    const viewport = env.viewport
+      ? `${env.viewport.width}×${env.viewport.height}`
+      : "";
+    return `
+      <article class="card">
+        <header>
+          <span class="kind kind-${kind}">${kind}</span>
+          <span class="reviewer">${reviewer || "(no name)"}</span>
+          <time>${receivedAt}</time>
+        </header>
+        <p class="comment">${comment}</p>
+        <dl>
+          <div><dt>URL</dt><dd><a href="${pageUrl}" target="_blank" rel="noopener">${pageUrl}</a></dd></div>
+          <div><dt>Title</dt><dd>${pageTitle}</dd></div>
+          <div><dt>Selector</dt><dd><code>${selector}</code></dd></div>
+          <div><dt>Viewport</dt><dd>${escapeHtml(viewport)}</dd></div>
+          <div><dt>Created</dt><dd>${createdAt}</dd></div>
+        </dl>
+        <details>
+          <summary>raw payload</summary>
+          <pre>${escapeHtml(JSON.stringify(item, null, 2))}</pre>
+        </details>
+      </article>
+    `;
+  });
+
+  return `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PatchLoop Inbox</title>
+  <style>
+    :root { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #14211d; }
+    body { margin: 0; padding: 24px; background: #f7f8f5; }
+    h1 { margin: 0 0 8px; font-size: 20px; }
+    .meta { color: #65716d; margin-bottom: 24px; font-size: 13px; }
+    .meta a { color: #0f7b63; }
+    .empty { color: #65716d; }
+    .card { background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; box-shadow: 0 4px 12px rgba(20, 33, 29, 0.05); }
+    .card header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 12px; color: #65716d; }
+    .kind { padding: 2px 8px; border-radius: 999px; font-weight: 800; color: #fff; font-size: 11px; text-transform: uppercase; }
+    .kind-point { background: #0f7b63; }
+    .kind-area { background: #d1495b; }
+    .reviewer { font-weight: 700; color: #14211d; }
+    time { margin-left: auto; }
+    .comment { font-size: 15px; margin: 0 0 12px; white-space: pre-wrap; }
+    dl { display: grid; grid-template-columns: 100px 1fr; gap: 4px 12px; margin: 0; font-size: 13px; }
+    dl > div { display: contents; }
+    dt { color: #65716d; }
+    dd { margin: 0; word-break: break-all; }
+    dd a { color: #0f7b63; }
+    code { font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f7f8f5; padding: 1px 4px; border-radius: 4px; }
+    details { margin-top: 10px; }
+    summary { cursor: pointer; font-size: 12px; color: #65716d; }
+    pre { background: #14211d; color: #c8d4cf; padding: 12px; border-radius: 6px; overflow-x: auto; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+  <h1>PatchLoop Inbox</h1>
+  <p class="meta">${items.length} feedback received · <a href="/feedback.json">raw JSON</a></p>
+  ${items.length === 0 ? '<p class="empty">まだフィードバックはありません。widget からコメントを送ると、ここに表示されます。</p>' : cards.join("")}
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

- 依存ゼロの Node http receiver を `server/receive.js` として追加。`POST /feedback` で payload を受け取り `server/feedback.json` に追記、`GET /` で簡易 inbox を表示する
- `examples/plain-html/` の `PatchLoop.init` に `endpoint: "http://localhost:4000/feedback"` を追加し、receiver と組み合わせるだけで送信→受信→閲覧が成立する
- README に receiver の起動・利用フローを追記。`feedback.json` は実行時データなので `.gitignore` で除外

Closes [#9](https://github.com/kosako/PatchLoop/issues/9)

参考: [Notion: Phase B 実装計画](https://www.notion.so/362da4d65cbb81859d57e082b0a870bb)

## Test plan

- [x] `node --check server/receive.js` 通過
- [x] `node server/receive.js` で起動 → `POST /feedback` に point / area の payload を投げて `server/feedback.json` に追記されることを確認
- [x] `GET /` で inbox HTML が描画され、kind バッジ（point / area）が出ることを確認
- [x] 不正 JSON で 400、未知パスで 404、`OPTIONS /feedback` で 204 + CORS ヘッダーを返すことを確認
- [x] 手動: ローカルブラウザで `examples/plain-html/` を開き、widget からコメント送信 → inbox に表示されるところまで通す

🤖 Generated with [Claude Code](https://claude.com/claude-code)