### PR TITLE
docs: align README with current widget API and payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
     projectId: "patchloop",
     demoId: "plain-html-renewal-review",
     reviewer: "Kosako",
+    endpoint: "http://localhost:4000/feedback",
     onSubmit(payload) {
       console.log(payload);
     }
@@ -54,21 +55,40 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 </script>
 ```
 
+### Init options
+
+- `projectId` (string) — payload に乗せるプロジェクト識別子
+- `demoId` (string) — payload に乗せるデモ識別子
+- `reviewer` (string, optional) — コメントフォームに初期表示する投稿者名
+- `endpoint` (string, optional) — payload を `POST` する URL。未設定なら送信しない
+- `onSubmit(payload)` (function, optional) — submit のたびに呼ばれる callback
+
+### window.PatchLoop API
+
+- `PatchLoop.init(options)` — widget をマウントしてキャプチャを開始
+- `PatchLoop.destroy()` — widget DOM・マーカー・ハイライトを全部撤去
+- `PatchLoop.setFeedbackMode(boolean)` — コメントモードを外部から切替
+- `PatchLoop.getFeedback()` — 現在の feedback 一覧のコピーを返す（newest first）
+
+### Events
+
+submit のたびに `document` で `patchloop:feedback` が発火し、`event.detail` に payload が入ります。`endpoint` の POST が終わるのを待たずに呼ばれます。
+
 基本操作:
 
 1. 右端のハンドルを押して drawer を開く
 2. 「コメントモード開始」を押す
 3. 画面上の場所をクリック、または範囲をドラッグする
-4. コメントを書いて送信する
-5. drawer の一覧に追加され、`onSubmit(payload)` でも payload を受け取る
+4. コメントと投稿者を書いて送信する
+5. drawer の一覧に追加され、`onSubmit(payload)` でも payload を受け取る。送信済みの項目は drawer 内から個別に編集・削除できる
 
 Basic flow:
 
 1. Click the right-edge handle to open the drawer
 2. Start comment mode
 3. Click a point or drag an area on the page
-4. Write and submit a comment
-5. The comment appears in the drawer list and is passed to `onSubmit(payload)`
+4. Write a comment and reviewer name, then submit
+5. The comment appears in the drawer list and is also passed to `onSubmit(payload)`. Each item can be edited or deleted from the list
 
 ## Payload
 
@@ -76,6 +96,7 @@ Basic flow:
 
 Main payload fields:
 
+- `id`
 - `projectId`
 - `demoId`
 - `comment`
@@ -96,11 +117,13 @@ Main payload fields:
 - `target.text`
 - `environment.viewport`
 - `environment.browser`
+- `environment.language`
 - `createdAt`
+- `delivery` — `endpoint` 設定時、POST 完了後に `{ ok, status }` または `{ ok: false, error }` が追加される
 
-`target.kind` は `point` または `area` です。範囲選択の場合は `target.area` に `x`, `y`, `width`, `height` が percentage で入ります。
+`target.kind` は `point` または `area` です。範囲選択の場合は `target.area` に viewport 上の percentage (`x` / `y` / `width` / `height`) に加えて、`clientX/Y/Width/Height`、`pageX/Y`、`documentX/Y/Width/Height` のピクセル値も入ります。
 
-`target.kind` is either `point` or `area`. For area selections, `target.area` includes `x`, `y`, `width`, and `height` as percentages.
+`target.kind` is either `point` or `area`. For area selections, `target.area` carries the viewport percentages (`x` / `y` / `width` / `height`) plus pixel values for `clientX/Y/Width/Height`, `pageX/Y`, and `documentX/Y/Width/Height`.
 
 `clientX/clientY` は現在の viewport 上の位置、`pageX/pageY` はスクロールを含む document 上の位置です。pin / area overlay は document 上に固定されるため、スクロールしても対象箇所に追従します。
 
@@ -132,9 +155,9 @@ node server/receive.js
 
 ## 現在の境界 / Current Boundary
 
-このバージョンは、まだ GitHub / Slack には直接送信しません。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。
+このバージョンは、まだ GitHub / Slack には直接送信しません。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
 
-This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver.
+This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
 
 未対応:
 


### PR DESCRIPTION
## Summary

- 埋め込み例の \`init\` に \`endpoint\` を追加
- 「Init options」「window.PatchLoop API」「Events」セクションを追加
- 基本操作に drawer 内の編集・削除を補足
- Payload field 一覧に \`id\` / \`delivery\` / \`environment.language\` を追加し、\`target.area\` の pixel フィールド群を明記
- 「現在の境界」に widget 一覧がメモリ保持のみである注記を追加

Closes [#17](https://github.com/kosako/PatchLoop/issues/17)

## Test plan

- [x] README が widget の現状仕様と一致する
- [x] 削除済みファイル / 古い launcher への参照が無い
- [x] init 例をコピペしてそのまま動かせる形になっている

## Out of scope

- 未実装機能の追加（Slack adapter / screenshot / GitHub Issue 連携）

🤖 Generated with [Claude Code](https://claude.com/claude-code)