### PR TITLE
docs: split README into Japanese and English files

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,140 @@
+# PatchLoop
+
+> 日本語版: [README.md](./README.md)
+
+PatchLoop is an experimental prototype for collecting browser-based visual feedback on AI-generated demos and turning that feedback into Slack, GitHub, or AI repair context.
+
+## Run Locally
+
+Serve the folder with any static file server and open `examples/plain-html/`.
+
+```sh
+python3 -m http.server 4173
+```
+
+```text
+http://localhost:4173/examples/plain-html/
+```
+
+## What Works Now
+
+script-tag widget:
+
+- Right-edge drawer with collapse handle that stays out of the way
+- Comment mode toggle in the drawer header (active state colours the handle)
+- Click-to-pin location capture and drag-to-select area capture
+- Draft markers that take their final sequential number on submit
+- Target element outline while a draft is pending
+- Per-feedback comment list with reviewer, kind, comment, and delivery status
+- Hover tooltip on markers showing the comment (disabled in feedback mode)
+- Per-item edit and delete inside the drawer with marker renumbering
+- Payload with URL, point/area position, selector, viewport, browser, reviewer, and timestamp
+- Optional `onSubmit(payload)` callback
+- Optional `endpoint` setting that POSTs payloads to the bundled local receiver
+
+## Embeddable Widget
+
+PatchLoop includes a standalone widget that can be embedded into a normal HTML page with a `script` tag.
+
+```html
+<script src="../../widget/patchloop-widget.js"></script>
+<script>
+  window.PatchLoop.init({
+    projectId: "patchloop",
+    demoId: "plain-html-renewal-review",
+    reviewer: "Kosako",
+    endpoint: "http://localhost:4000/feedback",
+    onSubmit(payload) {
+      console.log(payload);
+    }
+  });
+</script>
+```
+
+### Init options
+
+- `projectId` (string) — identifier carried in the payload
+- `demoId` (string) — identifier carried in the payload
+- `reviewer` (string, optional) — pre-fills the reviewer field in the comment form
+- `endpoint` (string, optional) — URL the widget POSTs each payload to; nothing is sent when omitted
+- `onSubmit(payload)` (function, optional) — called on every submit
+
+### window.PatchLoop API
+
+- `PatchLoop.init(options)` — mount the widget and start capturing
+- `PatchLoop.destroy()` — remove the widget DOM, markers, and highlights
+- `PatchLoop.setFeedbackMode(boolean)` — toggle comment mode programmatically
+- `PatchLoop.getFeedback()` — return a copy of the current feedback list (newest first)
+
+### Events
+
+`document` dispatches `patchloop:feedback` with `event.detail = payload` whenever a comment is submitted, before any `endpoint` POST resolves.
+
+### Basic flow
+
+1. Click the right-edge handle to open the drawer
+2. Start comment mode
+3. Click a point or drag an area on the page
+4. Write a comment and reviewer name, then submit
+5. The comment appears in the drawer list and is also passed to `onSubmit(payload)`. Each item can be edited or deleted from the list
+
+## Payload
+
+Main payload fields:
+
+- `id`
+- `projectId`
+- `demoId`
+- `comment`
+- `reviewer`
+- `page.url`
+- `page.title`
+- `target.kind`
+- `target.x`
+- `target.y`
+- `target.clientX`
+- `target.clientY`
+- `target.pageX`
+- `target.pageY`
+- `target.documentX`
+- `target.documentY`
+- `target.area`
+- `target.selector`
+- `target.text`
+- `environment.viewport`
+- `environment.browser`
+- `environment.language`
+- `createdAt`
+- `delivery` — added after the POST resolves when `endpoint` is set (`{ ok, status }` or `{ ok: false, error }`)
+
+`target.kind` is either `point` or `area`. For area selections, `target.area` carries the viewport percentages (`x` / `y` / `width` / `height`) plus pixel values for `clientX/Y/Width/Height`, `pageX/Y`, and `documentX/Y/Width/Height`.
+
+`clientX/clientY` represent viewport coordinates, while `pageX/pageY` represent document coordinates including scroll. Pins and area overlays are anchored to document coordinates so they stay attached to the target while scrolling.
+
+## Local Receiver
+
+When `endpoint` is set, the widget POSTs the payload to that URL. A local receiver is bundled for testing.
+
+```sh
+node server/receive.js
+```
+
+- Accepts payload at `POST /feedback`, appends to `server/feedback.json`
+- Renders an inbox of received feedback at `GET /`
+- Returns the raw JSON at `GET /feedback.json`
+- Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
+
+`examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
+
+## Current Boundary
+
+This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
+
+Not included yet:
+
+- Slack delivery
+- GitHub Issue creation
+- Persistent database
+- Real screenshot capture
+- Auth
+- AI PR integration

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # PatchLoop
 
+> English version: [README.en.md](./README.en.md)
+
 PatchLoop は、AI で作った demo / PoC に対してブラウザ上で直接フィードバックを残し、その内容を Slack / GitHub / AI 修正 PR につなげるための実験的プロトタイプです。
 
-PatchLoop is an experimental prototype for collecting browser-based visual feedback on AI-generated demos and turning that feedback into Slack, GitHub, or AI repair context.
-
-## ローカルで起動する / Run Locally
+## ローカルで起動する
 
 任意の静的ファイルサーバーで配信して `examples/plain-html/` を開きます。
-
-Serve the folder with any static file server and open `examples/plain-html/`.
 
 ```sh
 python3 -m http.server 4173
@@ -18,27 +16,25 @@ python3 -m http.server 4173
 http://localhost:4173/examples/plain-html/
 ```
 
-## 現在できること / What Works Now
+## 現在できること
 
 script-tag widget:
 
-- Right-edge drawer with collapse handle that stays out of the way
-- Comment mode toggle in the drawer header (active state colours the handle)
-- Click-to-pin location capture and drag-to-select area capture
-- Draft markers that take their final sequential number on submit
-- Target element outline while a draft is pending
-- Per-feedback comment list with reviewer, kind, comment, and delivery status
-- Hover tooltip on markers showing the comment (disabled in feedback mode)
-- Per-item edit and delete inside the drawer with marker renumbering
-- Payload with URL, point/area position, selector, viewport, browser, reviewer, and timestamp
-- Optional `onSubmit(payload)` callback
-- Optional `endpoint` setting that POSTs payloads to the bundled local receiver
+- 邪魔にならない右端ドロワー（折りたたみ時はハンドルのみ表示）
+- ドロワーヘッダーのコメントモード切り替え（モード ON 中はハンドルが赤くなる）
+- クリックで点キャプチャ、ドラッグで範囲キャプチャ
+- 送信前はドラフト表示、送信時に 1, 2, 3 と確定番号が振られる
+- ドラフト中、対象要素にダッシュドラインの outline
+- ドロワー内のコメント一覧（番号 / kind / reviewer / 本文 / 配送ステータス）
+- マーカーホバーでコメントのツールチップ表示（feedback モード中は無効）
+- 個別の編集・削除と残りマーカーの自動再番号付け
+- URL / 点・範囲位置 / selector / viewport / browser / reviewer / timestamp を含む payload
+- 任意の `onSubmit(payload)` callback
+- 任意の `endpoint` 設定で payload を receiver に POST
 
-## 埋め込み Widget / Embeddable Widget
+## 埋め込み Widget
 
 PatchLoop は、普通の HTML に `script` tag で埋め込める standalone widget を含んでいます。
-
-PatchLoop includes a standalone widget that can be embedded into a normal HTML page with a `script` tag.
 
 ```html
 <script src="../../widget/patchloop-widget.js"></script>
@@ -74,7 +70,7 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 
 submit のたびに `document` で `patchloop:feedback` が発火し、`event.detail` に payload が入ります。`endpoint` の POST が終わるのを待たずに呼ばれます。
 
-基本操作:
+### 基本操作
 
 1. 右端のハンドルを押して drawer を開く
 2. 「コメントモード開始」を押す
@@ -82,19 +78,9 @@ submit のたびに `document` で `patchloop:feedback` が発火し、`event.de
 4. コメントと投稿者を書いて送信する
 5. drawer の一覧に追加され、`onSubmit(payload)` でも payload を受け取る。送信済みの項目は drawer 内から個別に編集・削除できる
 
-Basic flow:
-
-1. Click the right-edge handle to open the drawer
-2. Start comment mode
-3. Click a point or drag an area on the page
-4. Write a comment and reviewer name, then submit
-5. The comment appears in the drawer list and is also passed to `onSubmit(payload)`. Each item can be edited or deleted from the list
-
 ## Payload
 
 主な payload 項目:
-
-Main payload fields:
 
 - `id`
 - `projectId`
@@ -123,17 +109,11 @@ Main payload fields:
 
 `target.kind` は `point` または `area` です。範囲選択の場合は `target.area` に viewport 上の percentage (`x` / `y` / `width` / `height`) に加えて、`clientX/Y/Width/Height`、`pageX/Y`、`documentX/Y/Width/Height` のピクセル値も入ります。
 
-`target.kind` is either `point` or `area`. For area selections, `target.area` carries the viewport percentages (`x` / `y` / `width` / `height`) plus pixel values for `clientX/Y/Width/Height`, `pageX/Y`, and `documentX/Y/Width/Height`.
-
 `clientX/clientY` は現在の viewport 上の位置、`pageX/pageY` はスクロールを含む document 上の位置です。pin / area overlay は document 上に固定されるため、スクロールしても対象箇所に追従します。
 
-`clientX/clientY` represent viewport coordinates, while `pageX/pageY` represent document coordinates including scroll. Pins and area overlays are anchored to document coordinates so they stay attached to the target while scrolling.
-
-## ローカル receiver / Local Receiver
+## ローカル receiver
 
 `endpoint` を指定すると、widget は payload をその URL に POST します。検証用のローカル receiver が同梱されています。
-
-When `endpoint` is set, the widget POSTs the payload to that URL. A local receiver is bundled for testing.
 
 ```sh
 node server/receive.js
@@ -144,28 +124,17 @@ node server/receive.js
 - `GET /feedback.json` で raw JSON を返します
 - `PORT` / `HOST` env で変更可能（デフォルトは `127.0.0.1:4000`）
 
-- Accepts payload at `POST /feedback`, appends to `server/feedback.json`
-- Renders an inbox of received feedback at `GET /`
-- Returns the raw JSON at `GET /feedback.json`
-- Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
-
 `examples/plain-html/` はデフォルトで `http://localhost:4000/feedback` に送信する設定です。`python3 -m http.server 4173` でページを配信した状態で receiver も起動すると、コメントが inbox に届きます。
 
-`examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
-
-## 現在の境界 / Current Boundary
+## 現在の境界
 
 このバージョンは、まだ GitHub / Slack には直接送信しません。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
 
-This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
-
 未対応:
 
-Not included yet:
-
-- Slack 投稿 / Slack delivery
-- GitHub Issue 作成 / GitHub Issue creation
-- 永続 DB / persistent database
-- 本物の screenshot capture / real screenshot capture
-- 認証 / auth
-- AI PR 連携 / AI PR integration
+- Slack 投稿
+- GitHub Issue 作成
+- 永続 DB
+- 本物の screenshot capture
+- 認証
+- AI PR 連携


### PR DESCRIPTION
## Summary

- `README.md` を日本語のみに整理（GitHub のデフォルト表示）
- 英語版を `README.en.md` として新規分離
- 双方の先頭に相互リンクを追加
- 中身の意味は変更なし。並列表記を解いただけ

Closes [#19](https://github.com/kosako/PatchLoop/issues/19)

## Test plan

- [x] `README.md` から英語段落が消えている
- [x] `README.en.md` が用意され英語のみで書かれている
- [x] 双方の先頭から相互リンクで遷移できる
- [x] 既存内容と差異がない（節立てとフィールド一覧）

## Out of scope

- 未実装機能の追加（Slack adapter / screenshot 等）
- 翻訳のブラッシュアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)