### PR TITLE
Slack webhook adapter を receiver に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 server/feedback.json
+server/receiver.config.json
 .DS_Store

--- a/README.en.md
+++ b/README.en.md
@@ -31,6 +31,7 @@ script-tag widget:
 - Payload with URL, point/area position, selector, viewport, browser, reviewer, and timestamp
 - Optional `onSubmit(payload)` callback
 - Optional `endpoint` setting that POSTs payloads to the bundled local receiver
+- Optional Slack Incoming Webhook forwarding from the local receiver
 
 ## Embeddable Widget
 
@@ -119,20 +120,31 @@ When `endpoint` is set, the widget POSTs the payload to that URL. A local receiv
 node server/receive.js
 ```
 
-- Accepts payload at `POST /feedback`, appends to `server/feedback.json`
+- Accepts payload at `POST /feedback`, appending to `server/feedback.json` by default
 - Renders an inbox of received feedback at `GET /`
 - Returns the raw JSON at `GET /feedback.json`
 - Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
+- Configurable storage path via `FEEDBACK_STORE_PATH`
+- Forwards received feedback to a Slack Incoming Webhook when `SLACK_WEBHOOK_URL` is set
+- Configurable Slack forwarding timeout via `SLACK_TIMEOUT_MS` (default `5000`)
 
 `examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
 
+To try Slack forwarding:
+
+```sh
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
+```
+
+If Slack forwarding fails, the receiver still stores the payload in `server/feedback.json`. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row.
+
 ## Current Boundary
 
-This version does not send to GitHub or Slack directly yet. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
+This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
 
 Not included yet:
 
-- Slack delivery
+- Slack App / OAuth integration
 - GitHub Issue creation
 - Persistent database
 - Real screenshot capture

--- a/README.en.md
+++ b/README.en.md
@@ -130,17 +130,37 @@ node server/receive.js
 
 `examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
 
-To try Slack forwarding:
+### Receiver Config File
+
+Local settings such as the Slack webhook URL can live in `server/receiver.config.json`. This file is ignored by git. A shareable template is available at `server/receiver.config.example.json`.
+
+```sh
+cp server/receiver.config.example.json server/receiver.config.json
+```
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 4000,
+  "feedbackStorePath": "feedback.json",
+  "slackWebhookUrl": "https://hooks.slack.com/services/...",
+  "slackTimeoutMs": 5000
+}
+```
+
+Relative `feedbackStorePath` values are resolved from the config file location. To use a config file from another path, run `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js`.
+
+Environment variables override the config file. For example, to try Slack forwarding temporarily:
 
 ```sh
 SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
-If Slack forwarding fails, the receiver still stores the payload in `server/feedback.json`. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row.
+If Slack forwarding fails, the receiver still stores the payload. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row.
 
 ## Current Boundary
 
-This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored in `server/feedback.json` by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
+This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
 
 Not included yet:
 

--- a/README.md
+++ b/README.md
@@ -130,17 +130,37 @@ node server/receive.js
 
 `examples/plain-html/` はデフォルトで `http://localhost:4000/feedback` に送信する設定です。`python3 -m http.server 4173` でページを配信した状態で receiver も起動すると、コメントが inbox に届きます。
 
-Slack 転送を試す場合:
+### Receiver 設定ファイル
+
+Slack webhook URL などのローカル設定は `server/receiver.config.json` に置けます。このファイルは git 管理外です。共有用テンプレートとして `server/receiver.config.example.json` を用意しています。
+
+```sh
+cp server/receiver.config.example.json server/receiver.config.json
+```
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 4000,
+  "feedbackStorePath": "feedback.json",
+  "slackWebhookUrl": "https://hooks.slack.com/services/...",
+  "slackTimeoutMs": 5000
+}
+```
+
+`feedbackStorePath` に相対パスを書く場合は、設定ファイルからの相対パスとして扱われます。別の場所の設定ファイルを使う場合は `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js` で指定できます。
+
+環境変数を指定した場合は設定ファイルより優先されます。たとえば一時的に Slack 転送を試す場合:
 
 ```sh
 SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
-Slack 転送に失敗しても、receiver は payload を `server/feedback.json` に保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。
+Slack 転送に失敗しても、receiver は payload を保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。
 
 ## 現在の境界
 
-このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
+このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
 
 未対応:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ script-tag widget:
 - URL / 点・範囲位置 / selector / viewport / browser / reviewer / timestamp を含む payload
 - 任意の `onSubmit(payload)` callback
 - 任意の `endpoint` 設定で payload を receiver に POST
+- ローカル receiver から任意の Slack Incoming Webhook へ転送
 
 ## 埋め込み Widget
 
@@ -119,20 +120,31 @@ submit のたびに `document` で `patchloop:feedback` が発火し、`event.de
 node server/receive.js
 ```
 
-- `POST /feedback` で payload を受け取り、`server/feedback.json` に追記します
+- `POST /feedback` で payload を受け取り、デフォルトでは `server/feedback.json` に追記します
 - `GET /` で受信した feedback の一覧（inbox）を表示します
 - `GET /feedback.json` で raw JSON を返します
 - `PORT` / `HOST` env で変更可能（デフォルトは `127.0.0.1:4000`）
+- `FEEDBACK_STORE_PATH` env で保存先を変更できます
+- `SLACK_WEBHOOK_URL` env を設定すると、受信した feedback を Slack Incoming Webhook にも転送します
+- `SLACK_TIMEOUT_MS` env で Slack 転送の timeout を変更できます（デフォルトは `5000`）
 
 `examples/plain-html/` はデフォルトで `http://localhost:4000/feedback` に送信する設定です。`python3 -m http.server 4173` でページを配信した状態で receiver も起動すると、コメントが inbox に届きます。
 
+Slack 転送を試す場合:
+
+```sh
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
+```
+
+Slack 転送に失敗しても、receiver は payload を `server/feedback.json` に保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。
+
 ## 現在の境界
 
-このバージョンは、まだ GitHub / Slack には直接送信しません。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
+このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver の `server/feedback.json` に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
 
 未対応:
 
-- Slack 投稿
+- Slack App / OAuth 連携
 - GitHub Issue 作成
 - 永続 DB
 - 本物の screenshot capture

--- a/server/receive.js
+++ b/server/receive.js
@@ -5,12 +5,16 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 
-const PORT = Number(process.env.PORT || 4000);
-const HOST = process.env.HOST || "127.0.0.1";
-const STORE_PATH = process.env.FEEDBACK_STORE_PATH || path.join(__dirname, "feedback.json");
+const CONFIG_PATH = process.env.PATCHLOOP_RECEIVER_CONFIG || path.join(__dirname, "receiver.config.json");
+const config = loadConfig(CONFIG_PATH);
+const configDir = path.dirname(CONFIG_PATH);
+
+const PORT = Number(process.env.PORT || config.port || 4000);
+const HOST = process.env.HOST || config.host || "127.0.0.1";
+const STORE_PATH = process.env.FEEDBACK_STORE_PATH || pathFromConfig(config.feedbackStorePath, path.join(__dirname, "feedback.json"));
 const MAX_BODY_BYTES = 1_000_000;
-const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL || "";
-const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || 5000);
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL || config.slackWebhookUrl || "";
+const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || config.slackTimeoutMs || 5000);
 
 let feedback = loadFeedback();
 
@@ -44,6 +48,7 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, HOST, () => {
   console.log(`[PatchLoop receiver] listening on http://${HOST}:${PORT}`);
+  console.log(`[PatchLoop receiver] config file: ${config.__loaded ? CONFIG_PATH : "not loaded"}`);
   console.log(`[PatchLoop receiver] feedback file: ${STORE_PATH}`);
   console.log(`[PatchLoop receiver] Slack webhook: ${SLACK_WEBHOOK_URL ? "enabled" : "disabled"}`);
 });
@@ -52,6 +57,26 @@ function setCors(res) {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+}
+
+function loadConfig(configPath) {
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object"
+      ? { ...parsed, __loaded: true }
+      : {};
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.warn(`[PatchLoop receiver] config file ignored: ${error.message}`);
+    }
+    return {};
+  }
+}
+
+function pathFromConfig(value, fallback) {
+  if (!value) return fallback;
+  return path.isAbsolute(value) ? value : path.resolve(configDir, value);
 }
 
 function handlePostFeedback(req, res) {

--- a/server/receive.js
+++ b/server/receive.js
@@ -1,13 +1,16 @@
 "use strict";
 
 const http = require("http");
+const https = require("https");
 const fs = require("fs");
 const path = require("path");
 
 const PORT = Number(process.env.PORT || 4000);
 const HOST = process.env.HOST || "127.0.0.1";
-const STORE_PATH = path.join(__dirname, "feedback.json");
+const STORE_PATH = process.env.FEEDBACK_STORE_PATH || path.join(__dirname, "feedback.json");
 const MAX_BODY_BYTES = 1_000_000;
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL || "";
+const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || 5000);
 
 let feedback = loadFeedback();
 
@@ -42,6 +45,7 @@ const server = http.createServer((req, res) => {
 server.listen(PORT, HOST, () => {
   console.log(`[PatchLoop receiver] listening on http://${HOST}:${PORT}`);
   console.log(`[PatchLoop receiver] feedback file: ${STORE_PATH}`);
+  console.log(`[PatchLoop receiver] Slack webhook: ${SLACK_WEBHOOK_URL ? "enabled" : "disabled"}`);
 });
 
 function setCors(res) {
@@ -67,7 +71,7 @@ function handlePostFeedback(req, res) {
     chunks.push(chunk);
   });
 
-  req.on("end", () => {
+  req.on("end", async () => {
     if (aborted) return;
     let payload;
     try {
@@ -77,10 +81,22 @@ function handlePostFeedback(req, res) {
       return;
     }
     const stored = { receivedAt: new Date().toISOString(), ...payload };
+    stored.integrations = {
+      ...(stored.integrations || {}),
+      slack: await deliverToSlack(stored)
+    };
     feedback.unshift(stored);
     persist();
-    console.log(`[PatchLoop receiver] received feedback id=${payload?.id || "?"} comment="${truncate(payload?.comment || "", 60)}"`);
-    respondJson(res, 201, { ok: true, id: payload?.id, count: feedback.length });
+    const slackLog = stored.integrations.slack.status === "disabled"
+      ? ""
+      : ` slack=${stored.integrations.slack.status}`;
+    console.log(`[PatchLoop receiver] received feedback id=${payload?.id || "?"} comment="${truncate(payload?.comment || "", 60)}"${slackLog}`);
+    respondJson(res, 201, {
+      ok: true,
+      id: payload?.id,
+      count: feedback.length,
+      slack: stored.integrations.slack
+    });
   });
 
   req.on("error", (error) => {
@@ -125,11 +141,154 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
+async function deliverToSlack(item) {
+  if (!SLACK_WEBHOOK_URL) {
+    return { status: "disabled" };
+  }
+
+  try {
+    const response = await postJson(SLACK_WEBHOOK_URL, buildSlackMessage(item));
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return { status: "sent", statusCode: response.statusCode };
+    }
+    return {
+      status: "failed",
+      statusCode: response.statusCode,
+      error: truncate(response.body || "Slack webhook returned a non-2xx response", 240)
+    };
+  } catch (error) {
+    return { status: "failed", error: error.message };
+  }
+}
+
+function postJson(targetUrl, body) {
+  return new Promise((resolve, reject) => {
+    let url;
+    try {
+      url = new URL(targetUrl);
+    } catch (error) {
+      reject(new Error(`Invalid SLACK_WEBHOOK_URL: ${error.message}`));
+      return;
+    }
+
+    const client = url.protocol === "https:" ? https : url.protocol === "http:" ? http : null;
+    if (!client) {
+      reject(new Error(`Unsupported webhook protocol: ${url.protocol}`));
+      return;
+    }
+
+    const json = JSON.stringify(body);
+    const request = client.request(url, {
+      method: "POST",
+      timeout: SLACK_TIMEOUT_MS,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(json),
+        "User-Agent": "PatchLoop receiver"
+      }
+    }, (response) => {
+      let raw = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        raw += chunk;
+      });
+      response.on("end", () => {
+        resolve({ statusCode: response.statusCode || 0, body: raw });
+      });
+    });
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Slack webhook timed out after ${SLACK_TIMEOUT_MS}ms`));
+    });
+    request.on("error", reject);
+    request.write(json);
+    request.end();
+  });
+}
+
+function buildSlackMessage(item) {
+  const target = item.target || {};
+  const env = item.environment || {};
+  const page = item.page || {};
+  const comment = slackEscape(truncate(item.comment || "(empty comment)", 1400));
+  const pageText = page.url
+    ? formatSlackLink(page.url, page.title || page.url)
+    : slackEscape(page.title || "(unknown page)");
+
+  return {
+    text: `PatchLoop feedback: ${truncate(item.comment || "", 120)}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*PatchLoop feedback*\n${comment}`
+        }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(item.reviewer || "(no name)")}` },
+          { type: "mrkdwn", text: `*Page*\n${pageText}` },
+          { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTarget(target))}` },
+          { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewport(env.viewport))}` },
+          { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
+          { type: "mrkdwn", text: `*Created*\n${slackEscape(item.createdAt || item.receivedAt || "(unknown)")}` }
+        ]
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `project: ${formatSlackCode(item.projectId || "-")} · demo: ${formatSlackCode(item.demoId || "-")}`
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function slackEscape(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function formatSlackCode(value) {
+  return `\`${slackEscape(truncate(String(value ?? "").replaceAll("`", "'"), 180))}\``;
+}
+
+function formatSlackLink(url, label) {
+  if (!/^https?:\/\//.test(url)) {
+    return slackEscape(url);
+  }
+  return `<${slackEscape(url)}|${slackEscape(truncate(String(label).replaceAll("|", "/"), 120))}>`;
+}
+
+function formatViewport(viewport) {
+  if (!viewport) return "(unknown)";
+  return `${present(viewport.width)}x${present(viewport.height)}`;
+}
+
+function formatTarget(target) {
+  if (target.kind === "area" && target.area) {
+    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
+  }
+  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
+}
+
+function present(value) {
+  return value === undefined || value === null || value === "" ? "?" : value;
+}
+
 function renderInbox(items) {
   const cards = items.map((item) => {
     const target = item.target || {};
     const env = item.environment || {};
     const page = item.page || {};
+    const slack = item.integrations && item.integrations.slack;
     const kind = escapeHtml(target.kind || "?");
     const selector = escapeHtml(target.selector || "");
     const pageUrl = escapeHtml(page.url || "");
@@ -154,6 +313,7 @@ function renderInbox(items) {
           <div><dt>Title</dt><dd>${pageTitle}</dd></div>
           <div><dt>Selector</dt><dd><code>${selector}</code></dd></div>
           <div><dt>Viewport</dt><dd>${escapeHtml(viewport)}</dd></div>
+          <div><dt>Slack</dt><dd>${escapeHtml(formatSlackStatus(slack))}</dd></div>
           <div><dt>Created</dt><dd>${createdAt}</dd></div>
         </dl>
         <details>
@@ -202,4 +362,11 @@ function renderInbox(items) {
   ${items.length === 0 ? '<p class="empty">まだフィードバックはありません。widget からコメントを送ると、ここに表示されます。</p>' : cards.join("")}
 </body>
 </html>`;
+}
+
+function formatSlackStatus(slack) {
+  if (!slack) return "unknown";
+  if (slack.status === "sent") return `sent (${slack.statusCode})`;
+  if (slack.status === "failed") return `failed${slack.statusCode ? ` (${slack.statusCode})` : ""}: ${slack.error || "unknown error"}`;
+  return slack.status || "unknown";
 }

--- a/server/receiver.config.example.json
+++ b/server/receiver.config.example.json
@@ -1,0 +1,7 @@
+{
+  "host": "127.0.0.1",
+  "port": 4000,
+  "feedbackStorePath": "feedback.json",
+  "slackWebhookUrl": "",
+  "slackTimeoutMs": 5000
+}


### PR DESCRIPTION
## Summary

- Add optional Slack Incoming Webhook forwarding from `server/receive.js`.
- Read local receiver settings from git-ignored `server/receiver.config.json`, with `server/receiver.config.example.json` as the tracked template.
- Preserve local inbox persistence even when Slack is disabled or forwarding fails, and store the result under `integrations.slack`.
- Show Slack status in the receiver inbox and document the receiver config/env vars in Japanese and English README files.

## Verification

- `node --check server/receive.js`
- `git diff --check`
- Local smoke test with a fake Slack webhook via env: receiver returns `201`, stores feedback, and records `integrations.slack.status = sent`
- Local smoke test with `SLACK_WEBHOOK_URL` unset: receiver returns `201`, stores feedback, and renders inbox with `integrations.slack.status = disabled`
- Local smoke test with `PATCHLOOP_RECEIVER_CONFIG`: receiver loads a config file, sends to a fake Slack webhook, and stores feedback relative to the config file path
- Manual local preview: `http://127.0.0.1:4173/examples/plain-html/` loads and the PatchLoop widget mounts
- Real Slack webhook test through `server/receiver.config.json`: receiver returned `201`, saved the feedback, and recorded `integrations.slack.status = sent` with `statusCode = 200`

Closes #21