### PR TITLE
Screenshot capture と Slack 通知改善を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 server/feedback.json
+server/screenshots/
 server/receiver.config.json
 .DS_Store

--- a/README.en.md
+++ b/README.en.md
@@ -29,9 +29,11 @@ script-tag widget:
 - Hover tooltip on markers showing the comment (disabled in feedback mode)
 - Per-item edit and delete inside the drawer with marker renumbering
 - Payload with URL, point/area position, selector, viewport, browser, reviewer, and timestamp
+- Lightweight viewport screenshot snapshot (SVG) attached to each payload
 - Optional `onSubmit(payload)` callback
 - Optional `endpoint` setting that POSTs payloads to the bundled local receiver
-- Optional Slack Incoming Webhook forwarding from the local receiver
+- Optional Slack Incoming Webhook forwarding from the local receiver with screenshot links, image blocks, and optional file upload
+- Configurable delivery mode for receiver forwarding, direct Slack webhook delivery, or no delivery
 
 ## Embeddable Widget
 
@@ -45,6 +47,7 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
     demoId: "plain-html-renewal-review",
     reviewer: "Kosako",
     endpoint: "http://localhost:4000/feedback",
+    showDeliverySettings: true,
     onSubmit(payload) {
       console.log(payload);
     }
@@ -57,7 +60,12 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 - `projectId` (string) — identifier carried in the payload
 - `demoId` (string) — identifier carried in the payload
 - `reviewer` (string, optional) — pre-fills the reviewer field in the comment form
+- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — delivery target; defaults to `"receiver"`
 - `endpoint` (string, optional) — URL the widget POSTs each payload to; nothing is sent when omitted
+- `slackWebhookUrl` (string, optional) — Slack Incoming Webhook URL used when `deliveryMode: "slack-webhook"`
+- `showDeliverySettings` (boolean, optional) — show the delivery target controls in the drawer; defaults to `false`
+- `captureScreenshot` (boolean, optional) — include a viewport snapshot in the payload; defaults to `true`
+- `screenshotMaxBytes` (number, optional) — widget-side byte limit before omitting the snapshot; defaults to `1200000`
 - `onSubmit(payload)` (function, optional) — called on every submit
 
 ### window.PatchLoop API
@@ -105,6 +113,7 @@ Main payload fields:
 - `environment.viewport`
 - `environment.browser`
 - `environment.language`
+- `screenshot` — viewport snapshot. On success it includes `status: "captured"`, `mimeType: "image/svg+xml"`, `dataUrl`, `targetOverlay`, and related metadata
 - `createdAt`
 - `delivery` — added after the POST resolves when `endpoint` is set (`{ ok, status }` or `{ ok: false, error }`)
 
@@ -123,9 +132,15 @@ node server/receive.js
 - Accepts payload at `POST /feedback`, appending to `server/feedback.json` by default
 - Renders an inbox of received feedback at `GET /`
 - Returns the raw JSON at `GET /feedback.json`
+- Serves saved screenshots from `GET /screenshots/:file`
 - Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
 - Configurable storage path via `FEEDBACK_STORE_PATH`
+- Configurable screenshot directory via `SCREENSHOT_DIR`
+- Configurable receiver URL for Slack links via `PUBLIC_BASE_URL`
+- Configurable payload and screenshot limits via `MAX_BODY_BYTES` / `SCREENSHOT_MAX_BYTES`
 - Forwards received feedback to a Slack Incoming Webhook when `SLACK_WEBHOOK_URL` is set
+- Configurable Slack screenshot presentation via `SLACK_IMAGE_MODE` (`auto` / `link` / `block` / `upload` / `off`)
+- Optional Slack file upload via `SLACK_BOT_TOKEN` and `SLACK_UPLOAD_CHANNEL_ID`
 - Configurable Slack forwarding timeout via `SLACK_TIMEOUT_MS` (default `5000`)
 
 `examples/plain-html/` is preconfigured to send to `http://localhost:4000/feedback`. Serve the page with `python3 -m http.server 4173`, start the receiver alongside it, and submitted comments will appear in the inbox.
@@ -143,12 +158,23 @@ cp server/receiver.config.example.json server/receiver.config.json
   "host": "127.0.0.1",
   "port": 4000,
   "feedbackStorePath": "feedback.json",
+  "screenshotDir": "screenshots",
+  "publicBaseUrl": "http://127.0.0.1:4000",
+  "maxBodyBytes": 3000000,
+  "screenshotMaxBytes": 1500000,
   "slackWebhookUrl": "https://hooks.slack.com/services/...",
+  "slackImageMode": "auto",
+  "slackBotToken": "",
+  "slackUploadChannelId": "",
   "slackTimeoutMs": 5000
 }
 ```
 
-Relative `feedbackStorePath` values are resolved from the config file location. To use a config file from another path, run `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js`.
+Relative `feedbackStorePath` and `screenshotDir` values are resolved from the config file location. `publicBaseUrl` is used for screenshot links and image blocks in Slack messages. For local testing, `http://127.0.0.1:4000` is enough. If you want Slack image previews to render outside your machine, point it at a public tunnel such as ngrok.
+
+`slackImageMode` defaults to `auto`. When `publicBaseUrl` is public, the receiver adds a Slack image block. When `slackBotToken` and `slackUploadChannelId` are also set, the receiver uploads the saved screenshot as a Slack file through the Slack Web API. The token needs the Slack App `files:write` scope. Use `link` for links only, `block` to force an image block, `upload` for file upload only, or `off` to omit screenshot presentation.
+
+To use a config file from another path, run `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js`.
 
 Environment variables override the config file. For example, to try Slack forwarding temporarily:
 
@@ -156,7 +182,20 @@ Environment variables override the config file. For example, to try Slack forwar
 SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
-If Slack forwarding fails, the receiver still stores the payload. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row.
+If Slack forwarding fails, the receiver still stores the payload. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row. Screenshot `dataUrl` values are saved as files by the receiver and replaced with `screenshot.url` in stored payloads.
+
+## Slack Direct Mode
+
+Use `deliveryMode: "slack-webhook"` to send directly from the browser to a Slack Incoming Webhook without running the receiver. When the drawer delivery settings are enabled, you can switch the target to `Slack direct` and enter the webhook URL in the UI.
+
+```js
+window.PatchLoop.init({
+  deliveryMode: "slack-webhook",
+  slackWebhookUrl: "https://hooks.slack.com/services/..."
+});
+```
+
+This exposes the webhook URL in the browser, so keep it to disposable testing webhooks in public environments. Incoming Webhooks cannot send a browser-generated `dataUrl` screenshot as a Slack image or file, so Slack direct mode sends the comment, page, target position, selector, viewport, and screenshot capture status. The screenshot data still remains available in the widget payload and `onSubmit`. To show or upload the generated screenshot in Slack, use receiver mode with `publicBaseUrl` or Slack file upload settings. Direct browser delivery uses `no-cors`, so the response body is not available to the widget.
 
 ## Current Boundary
 
@@ -167,6 +206,6 @@ Not included yet:
 - Slack App / OAuth integration
 - GitHub Issue creation
 - Persistent database
-- Real screenshot capture
+- Pixel-perfect browser screenshot capture
 - Auth
 - AI PR integration

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ script-tag widget:
 - マーカーホバーでコメントのツールチップ表示（feedback モード中は無効）
 - 個別の編集・削除と残りマーカーの自動再番号付け
 - URL / 点・範囲位置 / selector / viewport / browser / reviewer / timestamp を含む payload
+- viewport の lightweight screenshot snapshot（SVG）を payload に添付
 - 任意の `onSubmit(payload)` callback
 - 任意の `endpoint` 設定で payload を receiver に POST
-- ローカル receiver から任意の Slack Incoming Webhook へ転送
+- ローカル receiver から任意の Slack Incoming Webhook へ、スクショリンク / image block / 任意の file upload 付きで転送
+- 設定または drawer UI から、receiver 経由送信 / Slack webhook 直送 / 送信なしを切り替え
 
 ## 埋め込み Widget
 
@@ -45,6 +47,7 @@ PatchLoop は、普通の HTML に `script` tag で埋め込める standalone wi
     demoId: "plain-html-renewal-review",
     reviewer: "Kosako",
     endpoint: "http://localhost:4000/feedback",
+    showDeliverySettings: true,
     onSubmit(payload) {
       console.log(payload);
     }
@@ -57,7 +60,12 @@ PatchLoop は、普通の HTML に `script` tag で埋め込める standalone wi
 - `projectId` (string) — payload に乗せるプロジェクト識別子
 - `demoId` (string) — payload に乗せるデモ識別子
 - `reviewer` (string, optional) — コメントフォームに初期表示する投稿者名
+- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — 送信方式。デフォルトは `"receiver"`
 - `endpoint` (string, optional) — payload を `POST` する URL。未設定なら送信しない
+- `slackWebhookUrl` (string, optional) — `deliveryMode: "slack-webhook"` 時にブラウザから直接送る Slack Incoming Webhook URL
+- `showDeliverySettings` (boolean, optional) — drawer 内に送信先切替 UI を表示するか。デフォルトは `false`
+- `captureScreenshot` (boolean, optional) — viewport snapshot を payload に含めるか。デフォルトは `true`
+- `screenshotMaxBytes` (number, optional) — widget 側で snapshot を省略する最大バイト数。デフォルトは `1200000`
 - `onSubmit(payload)` (function, optional) — submit のたびに呼ばれる callback
 
 ### window.PatchLoop API
@@ -105,6 +113,7 @@ submit のたびに `document` で `patchloop:feedback` が発火し、`event.de
 - `environment.viewport`
 - `environment.browser`
 - `environment.language`
+- `screenshot` — viewport snapshot。成功時は `status: "captured"`、`mimeType: "image/svg+xml"`、`dataUrl`、`targetOverlay` などを含む
 - `createdAt`
 - `delivery` — `endpoint` 設定時、POST 完了後に `{ ok, status }` または `{ ok: false, error }` が追加される
 
@@ -123,9 +132,15 @@ node server/receive.js
 - `POST /feedback` で payload を受け取り、デフォルトでは `server/feedback.json` に追記します
 - `GET /` で受信した feedback の一覧（inbox）を表示します
 - `GET /feedback.json` で raw JSON を返します
+- `GET /screenshots/:file` で保存済み screenshot を返します
 - `PORT` / `HOST` env で変更可能（デフォルトは `127.0.0.1:4000`）
 - `FEEDBACK_STORE_PATH` env で保存先を変更できます
+- `SCREENSHOT_DIR` env で screenshot 保存先を変更できます
+- `PUBLIC_BASE_URL` env で Slack に載せる receiver の URL を指定できます
+- `MAX_BODY_BYTES` / `SCREENSHOT_MAX_BYTES` env で payload / screenshot の上限を変更できます
 - `SLACK_WEBHOOK_URL` env を設定すると、受信した feedback を Slack Incoming Webhook にも転送します
+- `SLACK_IMAGE_MODE` env で Slack 上の screenshot 表示方式を変更できます（`auto` / `link` / `block` / `upload` / `off`）
+- `SLACK_BOT_TOKEN` と `SLACK_UPLOAD_CHANNEL_ID` env を設定すると、保存済み screenshot を Slack file としてアップロードできます
 - `SLACK_TIMEOUT_MS` env で Slack 転送の timeout を変更できます（デフォルトは `5000`）
 
 `examples/plain-html/` はデフォルトで `http://localhost:4000/feedback` に送信する設定です。`python3 -m http.server 4173` でページを配信した状態で receiver も起動すると、コメントが inbox に届きます。
@@ -143,12 +158,23 @@ cp server/receiver.config.example.json server/receiver.config.json
   "host": "127.0.0.1",
   "port": 4000,
   "feedbackStorePath": "feedback.json",
+  "screenshotDir": "screenshots",
+  "publicBaseUrl": "http://127.0.0.1:4000",
+  "maxBodyBytes": 3000000,
+  "screenshotMaxBytes": 1500000,
   "slackWebhookUrl": "https://hooks.slack.com/services/...",
+  "slackImageMode": "auto",
+  "slackBotToken": "",
+  "slackUploadChannelId": "",
   "slackTimeoutMs": 5000
 }
 ```
 
-`feedbackStorePath` に相対パスを書く場合は、設定ファイルからの相対パスとして扱われます。別の場所の設定ファイルを使う場合は `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js` で指定できます。
+`feedbackStorePath` / `screenshotDir` に相対パスを書く場合は、設定ファイルからの相対パスとして扱われます。`publicBaseUrl` は Slack 通知内の screenshot link と image block に使われます。ローカル検証なら `http://127.0.0.1:4000` のままで十分です。外部の Slack 上で画像 preview まで表示したい場合は、ngrok などで公開した URL を指定してください。
+
+`slackImageMode` はデフォルト `auto` です。`publicBaseUrl` が公開 URL の場合は Slack message に image block を追加します。`slackBotToken` と `slackUploadChannelId` も設定されている場合は、Slack Web API で保存済み screenshot を file upload します。この token には Slack App の `files:write` scope が必要です。`link` はリンクのみ、`block` は image block を強制、`upload` は file upload のみ、`off` は screenshot 表示を送らない設定です。
+
+別の場所の設定ファイルを使う場合は `PATCHLOOP_RECEIVER_CONFIG=/path/to/receiver.config.json node server/receive.js` で指定できます。
 
 環境変数を指定した場合は設定ファイルより優先されます。たとえば一時的に Slack 転送を試す場合:
 
@@ -156,7 +182,20 @@ cp server/receiver.config.example.json server/receiver.config.json
 SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
-Slack 転送に失敗しても、receiver は payload を保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。
+Slack 転送に失敗しても、receiver は payload を保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。screenshot の `dataUrl` は receiver でファイル保存されたあと payload から取り除かれ、`screenshot.url` として参照されます。
+
+## Slack direct mode
+
+`deliveryMode: "slack-webhook"` を使うと、receiver を立てずにブラウザから Slack Incoming Webhook に直接送信できます。drawer UI を有効にしている場合は、画面上で送信先を `Slack direct` に切り替えて webhook URL を入力できます。
+
+```js
+window.PatchLoop.init({
+  deliveryMode: "slack-webhook",
+  slackWebhookUrl: "https://hooks.slack.com/services/..."
+});
+```
+
+このモードでは webhook URL がブラウザに見えるため、公開環境では使い捨ての検証用 webhook に限定してください。Incoming Webhook はブラウザ内で生成した `dataUrl` screenshot を Slack image/file として送れないため、Slack direct mode が Slack に送るのはコメント本文・ページ・対象位置・selector・viewport・screenshot 取得ステータスです。widget 内の payload と `onSubmit` には screenshot 情報が残ります。画像そのものを Slack に表示または file upload したい場合は、receiver mode で `publicBaseUrl` / `slackBotToken` / `slackUploadChannelId` を使ってください。ブラウザ直送は `no-cors` で投げるため、成功レスポンスの本文は取得できません。
 
 ## 現在の境界
 
@@ -167,6 +206,6 @@ Slack 転送に失敗しても、receiver は payload を保存します。Slack
 - Slack App / OAuth 連携
 - GitHub Issue 作成
 - 永続 DB
-- 本物の screenshot capture
+- pixel-perfect なブラウザ screenshot capture
 - 認証
 - AI PR 連携

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -81,6 +81,7 @@
         demoId: "plain-html-renewal-review",
         reviewer: "Kosako",
         endpoint: "http://localhost:4000/feedback",
+        showDeliverySettings: true,
         onSubmit(payload) {
           document.querySelector("#payloadOutput").textContent = JSON.stringify(payload, null, 2);
         }

--- a/server/receive.js
+++ b/server/receive.js
@@ -12,9 +12,15 @@ const configDir = path.dirname(CONFIG_PATH);
 const PORT = Number(process.env.PORT || config.port || 4000);
 const HOST = process.env.HOST || config.host || "127.0.0.1";
 const STORE_PATH = process.env.FEEDBACK_STORE_PATH || pathFromConfig(config.feedbackStorePath, path.join(__dirname, "feedback.json"));
-const MAX_BODY_BYTES = 1_000_000;
+const MAX_BODY_BYTES = Number(process.env.MAX_BODY_BYTES || config.maxBodyBytes || 3_000_000);
+const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || pathFromConfig(config.screenshotDir, path.join(__dirname, "screenshots"));
+const SCREENSHOT_MAX_BYTES = Number(process.env.SCREENSHOT_MAX_BYTES || config.screenshotMaxBytes || 1_500_000);
+const PUBLIC_BASE_URL = trimTrailingSlash(process.env.PUBLIC_BASE_URL || config.publicBaseUrl || `http://${HOST}:${PORT}`);
 const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL || config.slackWebhookUrl || "";
 const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || config.slackTimeoutMs || 5000);
+const SLACK_IMAGE_MODE = normalizeSlackImageMode(process.env.SLACK_IMAGE_MODE || config.slackImageMode || "auto");
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN || config.slackBotToken || "";
+const SLACK_UPLOAD_CHANNEL_ID = process.env.SLACK_UPLOAD_CHANNEL_ID || config.slackUploadChannelId || "";
 
 let feedback = loadFeedback();
 
@@ -42,6 +48,11 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (req.method === "GET" && req.url.startsWith("/screenshots/")) {
+    handleGetScreenshot(req, res);
+    return;
+  }
+
   res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
   res.end("Not Found");
 });
@@ -50,7 +61,10 @@ server.listen(PORT, HOST, () => {
   console.log(`[PatchLoop receiver] listening on http://${HOST}:${PORT}`);
   console.log(`[PatchLoop receiver] config file: ${config.__loaded ? CONFIG_PATH : "not loaded"}`);
   console.log(`[PatchLoop receiver] feedback file: ${STORE_PATH}`);
+  console.log(`[PatchLoop receiver] screenshot dir: ${SCREENSHOT_DIR}`);
   console.log(`[PatchLoop receiver] Slack webhook: ${SLACK_WEBHOOK_URL ? "enabled" : "disabled"}`);
+  console.log(`[PatchLoop receiver] Slack image mode: ${SLACK_IMAGE_MODE}`);
+  console.log(`[PatchLoop receiver] Slack file upload: ${SLACK_BOT_TOKEN && SLACK_UPLOAD_CHANNEL_ID ? "enabled" : "disabled"}`);
 });
 
 function setCors(res) {
@@ -79,6 +93,16 @@ function pathFromConfig(value, fallback) {
   return path.isAbsolute(value) ? value : path.resolve(configDir, value);
 }
 
+function trimTrailingSlash(value) {
+  return String(value || "").replace(/\/+$/, "");
+}
+
+function normalizeSlackImageMode(value) {
+  const mode = String(value || "").trim().toLowerCase();
+  if (["auto", "link", "block", "upload", "off"].includes(mode)) return mode;
+  return "auto";
+}
+
 function handlePostFeedback(req, res) {
   let received = 0;
   const chunks = [];
@@ -105,7 +129,15 @@ function handlePostFeedback(req, res) {
       respondJson(res, 400, { ok: false, error: "Invalid JSON" });
       return;
     }
-    const stored = { receivedAt: new Date().toISOString(), ...payload };
+    let screenshot;
+    try {
+      screenshot = saveScreenshot(payload.screenshot, payload.id);
+    } catch (error) {
+      respondJson(res, error.statusCode || 400, { ok: false, error: error.message });
+      return;
+    }
+
+    const stored = { receivedAt: new Date().toISOString(), ...payload, screenshot };
     stored.integrations = {
       ...(stored.integrations || {}),
       slack: await deliverToSlack(stored)
@@ -135,6 +167,39 @@ function handleGetInbox(req, res) {
   res.end(renderInbox(feedback));
 }
 
+function handleGetScreenshot(req, res) {
+  let filename;
+  try {
+    const url = new URL(req.url, "http://localhost");
+    filename = path.basename(decodeURIComponent(url.pathname));
+  } catch (_) {
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Invalid screenshot path");
+    return;
+  }
+
+  const screenshotPath = path.resolve(SCREENSHOT_DIR, filename);
+  const screenshotRoot = path.resolve(SCREENSHOT_DIR);
+  if (!screenshotPath.startsWith(`${screenshotRoot}${path.sep}`)) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Not Found");
+    return;
+  }
+
+  fs.readFile(screenshotPath, (error, buffer) => {
+    if (error) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not Found");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": contentTypeForPath(screenshotPath),
+      "Cache-Control": "no-store"
+    });
+    res.end(buffer);
+  });
+}
+
 function loadFeedback() {
   try {
     const raw = fs.readFileSync(STORE_PATH, "utf8");
@@ -146,7 +211,88 @@ function loadFeedback() {
 }
 
 function persist() {
+  fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
   fs.writeFileSync(STORE_PATH, JSON.stringify(feedback, null, 2));
+}
+
+function saveScreenshot(screenshot, id) {
+  if (!screenshot) return null;
+
+  const metadata = { ...screenshot };
+  delete metadata.dataUrl;
+
+  if (screenshot.status && screenshot.status !== "captured") {
+    return metadata;
+  }
+
+  if (!screenshot.dataUrl) {
+    return { ...metadata, status: "missing" };
+  }
+
+  const parsed = parseDataUrl(screenshot.dataUrl);
+  const extension = extensionForMimeType(parsed.mimeType);
+  if (!extension) {
+    throw httpError(`Unsupported screenshot mime type: ${parsed.mimeType}`, 400);
+  }
+
+  if (parsed.buffer.length > SCREENSHOT_MAX_BYTES) {
+    throw httpError(`Screenshot too large: ${parsed.buffer.length} bytes exceeds ${SCREENSHOT_MAX_BYTES}`, 413);
+  }
+
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  const fileName = `${safeFilePart(id || "feedback")}-${Date.now()}.${extension}`;
+  const filePath = path.join(SCREENSHOT_DIR, fileName);
+  fs.writeFileSync(filePath, parsed.buffer);
+
+  return {
+    ...metadata,
+    status: "saved",
+    mimeType: parsed.mimeType,
+    fileName,
+    path: filePath,
+    url: `${PUBLIC_BASE_URL}/screenshots/${encodeURIComponent(fileName)}`,
+    bytes: parsed.buffer.length
+  };
+}
+
+function parseDataUrl(dataUrl) {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(String(dataUrl || ""));
+  if (!match) {
+    throw httpError("Invalid screenshot data URL", 400);
+  }
+
+  return {
+    mimeType: match[1],
+    buffer: Buffer.from(match[2], "base64")
+  };
+}
+
+function extensionForMimeType(mimeType) {
+  if (mimeType === "image/svg+xml") return "svg";
+  if (mimeType === "image/png") return "png";
+  if (mimeType === "image/jpeg") return "jpg";
+  return "";
+}
+
+function contentTypeForPath(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".svg") return "image/svg+xml; charset=utf-8";
+  if (ext === ".png") return "image/png";
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  return "application/octet-stream";
+}
+
+function safeFilePart(value) {
+  return String(value || "feedback")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "feedback";
+}
+
+function httpError(message, statusCode) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
 }
 
 function respondJson(res, status, body) {
@@ -168,19 +314,33 @@ function escapeHtml(value) {
 
 async function deliverToSlack(item) {
   if (!SLACK_WEBHOOK_URL) {
-    return { status: "disabled" };
+    const image = await maybeUploadScreenshotToSlack(item);
+    if (image.status === "uploaded") {
+      return { status: "sent", image };
+    }
+    if (image.status === "disabled") {
+      return { status: "disabled" };
+    }
+    return { status: "failed", image, error: image.error || image.reason || "Slack webhook is disabled" };
   }
 
   try {
     const response = await postJson(SLACK_WEBHOOK_URL, buildSlackMessage(item));
+    const result = response.statusCode >= 200 && response.statusCode < 300
+      ? { status: "sent", statusCode: response.statusCode }
+      : {
+          status: "failed",
+          statusCode: response.statusCode,
+          error: truncate(response.body || "Slack webhook returned a non-2xx response", 240)
+        };
+
     if (response.statusCode >= 200 && response.statusCode < 300) {
-      return { status: "sent", statusCode: response.statusCode };
+      const image = await maybeUploadScreenshotToSlack(item);
+      if (image.status !== "disabled" && image.status !== "skipped") {
+        result.image = image;
+      }
     }
-    return {
-      status: "failed",
-      statusCode: response.statusCode,
-      error: truncate(response.body || "Slack webhook returned a non-2xx response", 240)
-    };
+    return result;
   } catch (error) {
     return { status: "failed", error: error.message };
   }
@@ -231,46 +391,251 @@ function postJson(targetUrl, body) {
   });
 }
 
+async function maybeUploadScreenshotToSlack(item) {
+  if (SLACK_IMAGE_MODE !== "auto" && SLACK_IMAGE_MODE !== "upload") {
+    return { status: "disabled" };
+  }
+
+  if (!SLACK_BOT_TOKEN || !SLACK_UPLOAD_CHANNEL_ID) {
+    return { status: "disabled" };
+  }
+
+  const screenshot = item.screenshot;
+  if (!screenshot || screenshot.status !== "saved" || !screenshot.path) {
+    return { status: "skipped", reason: "no saved screenshot" };
+  }
+
+  let buffer;
+  try {
+    buffer = await fs.promises.readFile(screenshot.path);
+  } catch (error) {
+    return { status: "failed", error: `Unable to read screenshot: ${error.message}` };
+  }
+
+  const filename = screenshot.fileName || path.basename(screenshot.path);
+  const title = `PatchLoop screenshot ${item.id || ""}`.trim();
+
+  try {
+    const uploadInit = await postSlackApi("files.getUploadURLExternal", {
+      filename,
+      length: buffer.length,
+      alt_txt: "PatchLoop viewport snapshot"
+    });
+
+    if (!uploadInit.ok || !uploadInit.upload_url || !uploadInit.file_id) {
+      return {
+        status: "failed",
+        error: uploadInit.error || "files.getUploadURLExternal failed"
+      };
+    }
+
+    const uploadResponse = await uploadBinary(uploadInit.upload_url, buffer, screenshot.mimeType || contentTypeForPath(filename));
+    if (uploadResponse.statusCode < 200 || uploadResponse.statusCode >= 300) {
+      return {
+        status: "failed",
+        statusCode: uploadResponse.statusCode,
+        error: truncate(uploadResponse.body || "upload_url returned a non-2xx response", 240)
+      };
+    }
+
+    const completed = await postSlackApi("files.completeUploadExternal", {
+      channel_id: SLACK_UPLOAD_CHANNEL_ID,
+      files: [
+        {
+          id: uploadInit.file_id,
+          title
+        }
+      ]
+    });
+
+    if (!completed.ok) {
+      return {
+        status: "failed",
+        fileId: uploadInit.file_id,
+        error: completed.error || "files.completeUploadExternal failed"
+      };
+    }
+
+    return {
+      status: "uploaded",
+      fileId: uploadInit.file_id,
+      channelId: SLACK_UPLOAD_CHANNEL_ID
+    };
+  } catch (error) {
+    return { status: "failed", error: error.message };
+  }
+}
+
+function postSlackApi(method, body) {
+  return new Promise((resolve, reject) => {
+    const json = JSON.stringify(body);
+    const request = https.request(`https://slack.com/api/${method}`, {
+      method: "POST",
+      timeout: SLACK_TIMEOUT_MS,
+      headers: {
+        "Authorization": `Bearer ${SLACK_BOT_TOKEN}`,
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": Buffer.byteLength(json),
+        "User-Agent": "PatchLoop receiver"
+      }
+    }, (response) => {
+      let raw = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        raw += chunk;
+      });
+      response.on("end", () => {
+        try {
+          resolve(JSON.parse(raw));
+        } catch (error) {
+          reject(new Error(`Slack API returned invalid JSON: ${error.message}`));
+        }
+      });
+    });
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Slack API timed out after ${SLACK_TIMEOUT_MS}ms`));
+    });
+    request.on("error", reject);
+    request.write(json);
+    request.end();
+  });
+}
+
+function uploadBinary(targetUrl, buffer, mimeType) {
+  return new Promise((resolve, reject) => {
+    let url;
+    try {
+      url = new URL(targetUrl);
+    } catch (error) {
+      reject(new Error(`Invalid Slack upload URL: ${error.message}`));
+      return;
+    }
+
+    const client = url.protocol === "https:" ? https : url.protocol === "http:" ? http : null;
+    if (!client) {
+      reject(new Error(`Unsupported upload protocol: ${url.protocol}`));
+      return;
+    }
+
+    const request = client.request(url, {
+      method: "POST",
+      timeout: SLACK_TIMEOUT_MS,
+      headers: {
+        "Content-Type": mimeType || "application/octet-stream",
+        "Content-Length": buffer.length,
+        "User-Agent": "PatchLoop receiver"
+      }
+    }, (response) => {
+      let raw = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        raw += chunk;
+      });
+      response.on("end", () => {
+        resolve({ statusCode: response.statusCode || 0, body: raw });
+      });
+    });
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Slack upload timed out after ${SLACK_TIMEOUT_MS}ms`));
+    });
+    request.on("error", reject);
+    request.write(buffer);
+    request.end();
+  });
+}
+
 function buildSlackMessage(item) {
   const target = item.target || {};
   const env = item.environment || {};
   const page = item.page || {};
   const comment = slackEscape(truncate(item.comment || "(empty comment)", 1400));
+  const screenshotUrl = screenshotUrlFor(item.screenshot);
   const pageText = page.url
     ? formatSlackLink(page.url, page.title || page.url)
     : slackEscape(page.title || "(unknown page)");
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "PatchLoop feedback",
+        emoji: false
+      }
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: comment
+      }
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(item.reviewer || "(no name)")}` },
+        { type: "mrkdwn", text: `*Page*\n${pageText}` },
+        { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTarget(target))}` },
+        { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewport(env.viewport))}` },
+        { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
+        { type: "mrkdwn", text: `*Created*\n${slackEscape(item.createdAt || item.receivedAt || "(unknown)")}` }
+      ]
+    }
+  ];
 
-  return {
-    text: `PatchLoop feedback: ${truncate(item.comment || "", 120)}`,
-    blocks: [
-      {
+  if (target.text) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Element text*\n>${slackEscape(truncate(target.text, 500)).replaceAll("\n", "\n>")}`
+      }
+    });
+  }
+
+  if (screenshotUrl) {
+    if (SLACK_IMAGE_MODE !== "off") {
+      blocks.push({
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*PatchLoop feedback*\n${comment}`
+          text: `*Screenshot*\n${formatSlackLink(screenshotUrl, "Open viewport snapshot")}`
         }
-      },
+      });
+    }
+    if (shouldSendSlackImageBlock(screenshotUrl)) {
+      blocks.push({
+        type: "image",
+        image_url: screenshotUrl,
+        alt_text: "PatchLoop viewport snapshot"
+      });
+    }
+  } else if (item.screenshot && item.screenshot.status) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `screenshot: ${formatSlackCode(formatScreenshotStatus(item.screenshot))}`
+        }
+      ]
+    });
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [
       {
-        type: "section",
-        fields: [
-          { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(item.reviewer || "(no name)")}` },
-          { type: "mrkdwn", text: `*Page*\n${pageText}` },
-          { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTarget(target))}` },
-          { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewport(env.viewport))}` },
-          { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
-          { type: "mrkdwn", text: `*Created*\n${slackEscape(item.createdAt || item.receivedAt || "(unknown)")}` }
-        ]
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: `project: ${formatSlackCode(item.projectId || "-")} · demo: ${formatSlackCode(item.demoId || "-")}`
-          }
-        ]
+        type: "mrkdwn",
+        text: `project: ${formatSlackCode(item.projectId || "-")} · demo: ${formatSlackCode(item.demoId || "-")} · id: ${formatSlackCode(item.id || "-")}`
       }
     ]
+  });
+
+  return {
+    text: `PatchLoop feedback: ${truncate(item.comment || "", 120)}`,
+    blocks
   };
 }
 
@@ -290,6 +655,46 @@ function formatSlackLink(url, label) {
     return slackEscape(url);
   }
   return `<${slackEscape(url)}|${slackEscape(truncate(String(label).replaceAll("|", "/"), 120))}>`;
+}
+
+function screenshotUrlFor(screenshot) {
+  if (!screenshot || screenshot.status !== "saved" || !screenshot.url) return "";
+  return screenshot.url;
+}
+
+function formatScreenshotStatus(screenshot) {
+  if (!screenshot) return "none";
+  if (screenshot.status === "omitted" && screenshot.reason === "too-large") {
+    return `omitted: ${present(screenshot.bytes)} bytes exceeds ${present(screenshot.maxBytes)}`;
+  }
+  if (screenshot.status === "saved") {
+    return `saved (${present(screenshot.bytes)} bytes)`;
+  }
+  return screenshot.status || "unknown";
+}
+
+function isLikelyPublicHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const host = url.hostname.toLowerCase();
+    if (host === "localhost" || host === "0.0.0.0" || host === "::1") return false;
+    if (host.startsWith("127.")) return false;
+    if (host.startsWith("10.")) return false;
+    if (host.startsWith("192.168.")) return false;
+    const private172 = /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
+    return !private172;
+  } catch (_) {
+    return false;
+  }
+}
+
+function shouldSendSlackImageBlock(screenshotUrl) {
+  if (!screenshotUrl || SLACK_IMAGE_MODE === "off" || SLACK_IMAGE_MODE === "link" || SLACK_IMAGE_MODE === "upload") {
+    return false;
+  }
+  if (SLACK_IMAGE_MODE === "block") return /^https?:\/\//.test(screenshotUrl);
+  return isLikelyPublicHttpUrl(screenshotUrl);
 }
 
 function formatViewport(viewport) {
@@ -314,6 +719,7 @@ function renderInbox(items) {
     const env = item.environment || {};
     const page = item.page || {};
     const slack = item.integrations && item.integrations.slack;
+    const screenshot = item.screenshot;
     const kind = escapeHtml(target.kind || "?");
     const selector = escapeHtml(target.selector || "");
     const pageUrl = escapeHtml(page.url || "");
@@ -333,6 +739,7 @@ function renderInbox(items) {
           <time>${receivedAt}</time>
         </header>
         <p class="comment">${comment}</p>
+        ${renderScreenshotPreview(screenshot)}
         <dl>
           <div><dt>URL</dt><dd><a href="${pageUrl}" target="_blank" rel="noopener">${pageUrl}</a></dd></div>
           <div><dt>Title</dt><dd>${pageTitle}</dd></div>
@@ -370,6 +777,11 @@ function renderInbox(items) {
     .reviewer { font-weight: 700; color: #14211d; }
     time { margin-left: auto; }
     .comment { font-size: 15px; margin: 0 0 12px; white-space: pre-wrap; }
+    .screenshot { margin: 0 0 12px; border: 1px solid #d9e1dd; border-radius: 8px; overflow: hidden; background: #f7f8f5; }
+    .screenshot a { display: block; }
+    .screenshot img { display: block; width: 100%; max-height: 360px; object-fit: contain; background: #fff; }
+    .screenshot figcaption, .screenshot-note { margin: 0 0 12px; color: #65716d; font-size: 12px; }
+    .screenshot figcaption { padding: 8px 10px; border-top: 1px solid #d9e1dd; margin: 0; }
     dl { display: grid; grid-template-columns: 100px 1fr; gap: 4px 12px; margin: 0; font-size: 13px; }
     dl > div { display: contents; }
     dt { color: #65716d; }
@@ -389,9 +801,34 @@ function renderInbox(items) {
 </html>`;
 }
 
+function renderScreenshotPreview(screenshot) {
+  if (!screenshot) return "";
+  if (screenshot.status === "saved" && screenshot.url) {
+    const url = escapeHtml(screenshot.url);
+    const size = screenshot.width && screenshot.height
+      ? `${screenshot.width}×${screenshot.height}`
+      : "";
+    const bytes = screenshot.bytes ? `${screenshot.bytes} bytes` : "";
+    const caption = [size, bytes].filter(Boolean).join(" · ");
+    return `
+        <figure class="screenshot">
+          <a href="${url}" target="_blank" rel="noopener">
+            <img src="${url}" alt="PatchLoop screenshot preview" />
+          </a>
+          <figcaption>${escapeHtml(caption || "screenshot saved")}</figcaption>
+        </figure>
+    `;
+  }
+
+  return `<p class="screenshot-note">Screenshot: ${escapeHtml(formatScreenshotStatus(screenshot))}</p>`;
+}
+
 function formatSlackStatus(slack) {
   if (!slack) return "unknown";
-  if (slack.status === "sent") return `sent (${slack.statusCode})`;
+  const image = slack.image && slack.image.status
+    ? `, image ${slack.image.status}`
+    : "";
+  if (slack.status === "sent") return `sent${slack.statusCode ? ` (${slack.statusCode})` : ""}${image}`;
   if (slack.status === "failed") return `failed${slack.statusCode ? ` (${slack.statusCode})` : ""}: ${slack.error || "unknown error"}`;
   return slack.status || "unknown";
 }

--- a/server/receiver.config.example.json
+++ b/server/receiver.config.example.json
@@ -2,6 +2,13 @@
   "host": "127.0.0.1",
   "port": 4000,
   "feedbackStorePath": "feedback.json",
+  "screenshotDir": "screenshots",
+  "publicBaseUrl": "http://127.0.0.1:4000",
+  "maxBodyBytes": 3000000,
+  "screenshotMaxBytes": 1500000,
   "slackWebhookUrl": "",
+  "slackImageMode": "auto",
+  "slackBotToken": "",
+  "slackUploadChannelId": "",
   "slackTimeoutMs": 5000
 }

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -5,8 +5,13 @@
     projectId: "local-demo",
     demoId: "plain-html",
     endpoint: "",
+    deliveryMode: "receiver",
+    slackWebhookUrl: "",
+    showDeliverySettings: false,
     reviewer: "",
     position: "bottom-right",
+    captureScreenshot: true,
+    screenshotMaxBytes: 1_200_000,
     onSubmit: null
   };
 
@@ -67,6 +72,7 @@
           <div class="pl-actions">
             <button type="button" data-pl-clear>ピンを消す</button>
           </div>
+          ${renderDeliverySettings()}
           <div class="pl-feedback-list" data-pl-list>
             <p class="pl-feedback-list-empty">まだフィードバックはありません。</p>
           </div>
@@ -97,6 +103,35 @@
     root.querySelector("[data-pl-cancel]").addEventListener("click", cancelPendingComment);
     root.querySelector("[data-pl-comment]").addEventListener("submit", submitComment);
     root.querySelector("[data-pl-list]").addEventListener("click", handleListClick);
+    root.querySelector("[data-pl-delivery-settings]")?.addEventListener("input", handleDeliverySettingsInput);
+    root.querySelector("[data-pl-delivery-settings]")?.addEventListener("change", handleDeliverySettingsInput);
+    syncDeliverySettingsVisibility();
+  }
+
+  function renderDeliverySettings() {
+    if (!state.options.showDeliverySettings) return "";
+
+    return `
+          <details class="pl-delivery-settings" data-pl-delivery-settings>
+            <summary>送信設定</summary>
+            <label>
+              送信先
+              <select data-pl-delivery-mode>
+                <option value="receiver"${state.options.deliveryMode === "receiver" ? " selected" : ""}>Receiver</option>
+                <option value="slack-webhook"${state.options.deliveryMode === "slack-webhook" ? " selected" : ""}>Slack direct</option>
+                <option value="none"${state.options.deliveryMode === "none" ? " selected" : ""}>送信なし</option>
+              </select>
+            </label>
+            <label data-pl-endpoint-field>
+              Receiver endpoint
+              <input data-pl-endpoint value="${escapeHtml(state.options.endpoint)}" placeholder="http://localhost:4000/feedback" />
+            </label>
+            <label data-pl-slack-field>
+              Slack webhook URL
+              <input type="password" data-pl-slack-webhook value="${escapeHtml(state.options.slackWebhookUrl)}" placeholder="https://hooks.slack.com/services/..." />
+            </label>
+          </details>
+    `;
   }
 
   function bindGlobalCapture() {
@@ -253,6 +288,29 @@
     state.pendingTarget = null;
   }
 
+  function handleDeliverySettingsInput() {
+    const root = getRoot();
+    if (!root) return;
+    const mode = root.querySelector("[data-pl-delivery-mode]")?.value;
+    const endpoint = root.querySelector("[data-pl-endpoint]")?.value;
+    const slackWebhookUrl = root.querySelector("[data-pl-slack-webhook]")?.value;
+
+    if (mode) state.options.deliveryMode = mode;
+    if (endpoint != null) state.options.endpoint = endpoint.trim();
+    if (slackWebhookUrl != null) state.options.slackWebhookUrl = slackWebhookUrl.trim();
+    syncDeliverySettingsVisibility();
+  }
+
+  function syncDeliverySettingsVisibility() {
+    const root = getRoot();
+    if (!root) return;
+    const mode = state.options.deliveryMode || "receiver";
+    const endpointField = root.querySelector("[data-pl-endpoint-field]");
+    const slackField = root.querySelector("[data-pl-slack-field]");
+    if (endpointField) endpointField.hidden = mode !== "receiver";
+    if (slackField) slackField.hidden = mode !== "slack-webhook";
+  }
+
   async function submitComment(event) {
     event.preventDefault();
 
@@ -289,8 +347,8 @@
       state.options.onSubmit(payload);
     }
 
-    if (state.options.endpoint) {
-      await postFeedback(payload);
+    if (shouldDeliverFeedback()) {
+      await deliverFeedback(payload);
       renderFeedbackList();
     }
   }
@@ -328,8 +386,158 @@
         browser: navigator.userAgent,
         language: navigator.language
       },
+      screenshot: captureScreenshot(target),
       createdAt: new Date().toISOString()
     };
+  }
+
+  function captureScreenshot(target) {
+    if (!state.options.captureScreenshot) return null;
+
+    try {
+      const width = Math.max(document.documentElement.clientWidth, window.innerWidth, 1);
+      const height = Math.max(document.documentElement.clientHeight, window.innerHeight, 1);
+      const documentWidth = Math.max(document.documentElement.scrollWidth, width);
+      const documentHeight = Math.max(document.documentElement.scrollHeight, height);
+      const overlay = screenshotOverlayFor(target);
+      const svg = buildScreenshotSvg({
+        width,
+        height,
+        documentWidth,
+        documentHeight,
+        scrollX: window.scrollX,
+        scrollY: window.scrollY,
+        overlay
+      });
+      const bytes = byteLength(svg);
+      const maxBytes = Number(state.options.screenshotMaxBytes || 0);
+
+      if (maxBytes > 0 && bytes > maxBytes) {
+        return {
+          status: "omitted",
+          reason: "too-large",
+          kind: "viewport-svg",
+          mimeType: "image/svg+xml",
+          width,
+          height,
+          bytes,
+          maxBytes,
+          targetOverlay: overlay
+        };
+      }
+
+      return {
+        status: "captured",
+        kind: "viewport-svg",
+        mimeType: "image/svg+xml",
+        width,
+        height,
+        scrollX: Math.round(window.scrollX),
+        scrollY: Math.round(window.scrollY),
+        devicePixelRatio: window.devicePixelRatio || 1,
+        bytes,
+        targetOverlay: overlay,
+        dataUrl: `data:image/svg+xml;base64,${base64Encode(svg)}`
+      };
+    } catch (error) {
+      return {
+        status: "failed",
+        error: error.message
+      };
+    }
+  }
+
+  function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scrollX, scrollY, overlay }) {
+    const bodyClone = document.body.cloneNode(true);
+    bodyClone.querySelectorAll("[data-patchloop-root], [data-patchloop-pin], [data-patchloop-area], [data-patchloop-selection], script").forEach((node) => node.remove());
+    bodyClone.querySelectorAll(".pl-target-highlight").forEach((node) => node.classList.remove("pl-target-highlight"));
+
+    const bodyStyle = window.getComputedStyle(document.body);
+    const background = bodyStyle.backgroundColor || "#ffffff";
+    const color = bodyStyle.color || "#14211d";
+    const font = bodyStyle.font || bodyStyle.fontFamily || "system-ui, sans-serif";
+    const styles = `${collectReadableStyles()}\n* { box-sizing: border-box; }\n`;
+    const overlayMarkup = renderScreenshotOverlay(overlay);
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <rect width="100%" height="100%" fill="${escapeXml(background)}"/>
+  <foreignObject x="0" y="0" width="${width}" height="${height}">
+    <html xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px;height:${height}px;overflow:hidden;background:${escapeHtml(background)};">
+      <head>
+        <style><![CDATA[${styles.replaceAll("]]>", "]]]]><![CDATA[>")}]]></style>
+      </head>
+      <body style="margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
+        ${bodyClone.innerHTML}
+      </body>
+    </html>
+  </foreignObject>
+  <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" fill="none" stroke="#d9e1dd"/>
+  ${overlayMarkup}
+</svg>`;
+  }
+
+  function collectReadableStyles() {
+    const chunks = [];
+    Array.from(document.styleSheets).forEach((sheet) => {
+      try {
+        if (sheet.ownerNode?.dataset?.patchloopStyle) return;
+        chunks.push(Array.from(sheet.cssRules || []).map((rule) => rule.cssText).join("\n"));
+      } catch (_) {
+        // Cross-origin stylesheets cannot be read. The snapshot still includes DOM and overlay context.
+      }
+    });
+    return chunks.join("\n");
+  }
+
+  function screenshotOverlayFor(target) {
+    if (target.kind === "area" && target.area) {
+      return {
+        kind: "area",
+        x: Math.round(target.area.clientX),
+        y: Math.round(target.area.clientY),
+        width: Math.round(target.area.clientWidth),
+        height: Math.round(target.area.clientHeight)
+      };
+    }
+
+    return {
+      kind: "point",
+      x: Math.round(target.clientX),
+      y: Math.round(target.clientY)
+    };
+  }
+
+  function renderScreenshotOverlay(overlay) {
+    if (!overlay) return "";
+    if (overlay.kind === "area") {
+      const x = Math.max(0, overlay.x);
+      const y = Math.max(0, overlay.y);
+      const width = Math.max(1, overlay.width);
+      const height = Math.max(1, overlay.height);
+      return `
+  <rect x="${x}" y="${y}" width="${width}" height="${height}" rx="6" fill="rgba(209, 73, 91, 0.16)" stroke="#d1495b" stroke-width="3"/>
+  <circle cx="${x + 18}" cy="${y + 18}" r="14" fill="#d1495b" stroke="#ffffff" stroke-width="3"/>
+  <text x="${x + 18}" y="${y + 23}" text-anchor="middle" fill="#ffffff" font-family="system-ui, sans-serif" font-size="13" font-weight="900">!</text>`;
+    }
+
+    return `
+  <circle cx="${overlay.x}" cy="${overlay.y}" r="18" fill="#d1495b" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="${overlay.x}" cy="${overlay.y}" r="30" fill="none" stroke="#d1495b" stroke-width="3" opacity="0.35"/>`;
+  }
+
+  function byteLength(value) {
+    if (window.Blob) return new Blob([value]).size;
+    return base64Encode(value).length;
+  }
+
+  function base64Encode(value) {
+    const bytes = new TextEncoder().encode(value);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += 8192) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+    }
+    return btoa(binary);
   }
 
   async function postFeedback(payload) {
@@ -344,6 +552,156 @@
       payload.delivery = { ok: false, error: error.message };
     }
     console.info("[PatchLoop] delivery", payload.id, payload.delivery);
+  }
+
+  function shouldDeliverFeedback() {
+    if (state.options.deliveryMode === "none") return false;
+    if (state.options.deliveryMode === "slack-webhook") return Boolean(state.options.slackWebhookUrl);
+    return Boolean(state.options.endpoint);
+  }
+
+  async function deliverFeedback(payload) {
+    if (state.options.deliveryMode === "slack-webhook") {
+      await postSlackWebhook(payload);
+      return;
+    }
+
+    await postFeedback(payload);
+  }
+
+  async function postSlackWebhook(payload) {
+    try {
+      await fetch(state.options.slackWebhookUrl, {
+        method: "POST",
+        mode: "no-cors",
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        body: JSON.stringify(buildSlackWebhookPayload(payload))
+      });
+      payload.delivery = { ok: true, status: "opaque", target: "slack-webhook" };
+    } catch (error) {
+      payload.delivery = { ok: false, target: "slack-webhook", error: error.message };
+    }
+    console.info("[PatchLoop] delivery", payload.id, payload.delivery);
+  }
+
+  function buildSlackWebhookPayload(payload) {
+    const target = payload.target || {};
+    const env = payload.environment || {};
+    const page = payload.page || {};
+    const blocks = [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "PatchLoop feedback",
+          emoji: false
+        }
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: slackEscape(truncateText(payload.comment || "(empty comment)", 1400))
+        }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(payload.reviewer || "(no name)")}` },
+          { type: "mrkdwn", text: `*Page*\n${formatSlackLink(page.url, page.title || page.url || "(unknown page)")}` },
+          { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTargetForSlack(target))}` },
+          { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewportForSlack(env.viewport))}` },
+          { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
+          { type: "mrkdwn", text: `*Created*\n${slackEscape(payload.createdAt || "(unknown)")}` }
+        ]
+      }
+    ];
+
+    if (target.text) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Element text*\n>${slackEscape(truncateText(target.text, 500)).replaceAll("\n", "\n>")}`
+        }
+      });
+    }
+
+    if (payload.screenshot && payload.screenshot.status) {
+      blocks.push({
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `screenshot: ${formatSlackCode(formatDirectScreenshotStatus(payload.screenshot))}`
+          }
+        ]
+      });
+    }
+
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `project: ${formatSlackCode(payload.projectId || "-")} · demo: ${formatSlackCode(payload.demoId || "-")} · id: ${formatSlackCode(payload.id || "-")}`
+        }
+      ]
+    });
+
+    return {
+      text: `PatchLoop feedback: ${truncateText(payload.comment || "", 120)}`,
+      blocks
+    };
+  }
+
+  function slackEscape(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;");
+  }
+
+  function formatSlackCode(value) {
+    return `\`${slackEscape(truncateText(String(value ?? "").replaceAll("`", "'"), 180))}\``;
+  }
+
+  function formatSlackLink(url, label) {
+    if (!/^https?:\/\//.test(url || "")) {
+      return slackEscape(label || url || "(unknown)");
+    }
+    return `<${slackEscape(url)}|${slackEscape(truncateText(String(label || url).replaceAll("|", "/"), 120))}>`;
+  }
+
+  function formatViewportForSlack(viewport) {
+    if (!viewport) return "(unknown)";
+    return `${present(viewport.width)}x${present(viewport.height)}`;
+  }
+
+  function formatTargetForSlack(target) {
+    if (target.kind === "area" && target.area) {
+      return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
+    }
+    return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
+  }
+
+  function formatDirectScreenshotStatus(screenshot) {
+    if (screenshot.status === "captured") {
+      return "captured locally; direct Slack mode needs a public image URL";
+    }
+    if (screenshot.status === "omitted" && screenshot.reason === "too-large") {
+      return `omitted: ${present(screenshot.bytes)} bytes exceeds ${present(screenshot.maxBytes)}`;
+    }
+    return screenshot.status || "unknown";
+  }
+
+  function truncateText(value, max) {
+    const text = String(value ?? "");
+    return text.length > max ? `${text.slice(0, max)}…` : text;
+  }
+
+  function present(value) {
+    return value === undefined || value === null || value === "" ? "?" : value;
   }
 
   function addPin(point) {
@@ -724,6 +1082,10 @@
       .replaceAll('"', "&quot;");
   }
 
+  function escapeXml(value) {
+    return escapeHtml(value).replaceAll("'", "&apos;");
+  }
+
   function injectStyles() {
     if (document.querySelector("[data-patchloop-style]")) return;
     const style = document.createElement("style");
@@ -750,6 +1112,10 @@
       .pl-actions { display: flex; gap: 8px; padding: 0 14px 14px; }
       .pl-actions button, .pl-form-actions button { min-height: 36px; border-radius: 8px; border: 1px solid #d9e1dd; background: #fff; color: #14211d; padding: 0 12px; cursor: pointer; }
       .pl-form-actions button[type="submit"] { background: #0f7b63; border-color: #0f7b63; color: #fff; font-weight: 800; }
+      .pl-delivery-settings { margin: 0 14px 14px; border: 1px solid #d9e1dd; border-radius: 8px; padding: 8px 10px 10px; background: #f7f8f5; }
+      .pl-delivery-settings summary { cursor: pointer; color: #14211d; font-weight: 800; font-size: 12px; }
+      .pl-delivery-settings label { display: grid; gap: 5px; margin-top: 8px; color: #65716d; font-size: 11px; font-weight: 800; }
+      .pl-delivery-settings input, .pl-delivery-settings select { width: 100%; min-height: 32px; border: 1px solid #d9e1dd; border-radius: 6px; background: #fff; color: #14211d; padding: 6px 8px; font: inherit; }
       .pl-feedback-list { max-height: 280px; overflow-y: auto; padding: 0 14px 14px; display: grid; gap: 8px; }
       .pl-feedback-list-empty { margin: 0; color: #65716d; font-size: 13px; padding: 0; }
       .pl-feedback-item { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; padding: 10px; border: 1px solid #d9e1dd; border-radius: 8px; background: #fff; align-items: start; }


### PR DESCRIPTION
## Summary
- Widget payload に viewport SVG snapshot を追加し、point/area の対象位置を snapshot 上にも表示
- Receiver で screenshot を git 管理外の `server/screenshots/` に保存し、Inbox preview と `/screenshots/:file` 配信を追加
- Slack 通知を Block Kit 形式に拡張し、comment/target/viewport/screenshot link/image block を見やすく整理
- `slackImageMode` を追加し、公開 URL の image block と Slack Files API での任意 file upload に対応
- Widget に `deliveryMode` と drawer の送信設定 UI を追加し、receiver 経由 / Slack direct / 送信なしを切替可能に
- Slack direct mode はサーバなし利用を前提に、Slack へはコメント・対象情報・screenshot 取得ステータスを送信。画像送信は receiver mode に集約
- README / README.en に receiver config、Slack direct mode、画像送信の制約を追記

Closes #23

## Validation
- `node --check widget/patchloop-widget.js`
- `node --check server/receive.js`
- `git diff --check`
- Local receiver smoke test: screenshot data URL persisted and served from `/screenshots/:file`
- Fake Slack webhook smoke test: receiver payload includes screenshot link and image block
- Browser UI smoke test on `http://127.0.0.1:4174/examples/plain-html/`: delivery settings UI rendered, direct mode shows only webhook URL, and mode visibility toggled
- Browser console check: no error/warning logs after UI verification
- Previous real Slack webhook smoke: feedback submitted, Slack webhook returned 200, Inbox preview rendered
- Oversized screenshot test: receiver returns 413 when `SCREENSHOT_MAX_BYTES` is exceeded
