### PR TITLE
Reviewer 名の必須化と localStorage 保存を追加する

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -45,7 +45,6 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
   window.PatchLoop.init({
     projectId: "patchloop",
     demoId: "plain-html-renewal-review",
-    reviewer: "Kosako",
     endpoint: "http://localhost:4000/feedback",
     showDeliverySettings: true,
     onSubmit(payload) {
@@ -59,7 +58,8 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 
 - `projectId` (string) — identifier carried in the payload
 - `demoId` (string) — identifier carried in the payload
-- `reviewer` (string, optional) — pre-fills the reviewer field in the comment form
+- `reviewer` (string, optional) — pre-fills the reviewer field in the comment form. When omitted, the widget restores a saved reviewer from `localStorage`; otherwise the field starts empty
+- `reviewerStorageKey` (string, optional) — `localStorage` key used to persist the reviewer name; defaults to `patchloop:reviewer`
 - `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — delivery target; defaults to `"receiver"`
 - `endpoint` (string, optional) — URL the widget POSTs each payload to; nothing is sent when omitted
 - `slackWebhookUrl` (string, optional) — Slack Incoming Webhook URL used when `deliveryMode: "slack-webhook"`
@@ -84,8 +84,10 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 1. Click the right-edge handle to open the drawer
 2. Start comment mode
 3. Click a point or drag an area on the page
-4. Write a comment and reviewer name, then submit
+4. Write a comment and reviewer name, then submit. Feedback cannot be submitted while the reviewer is blank
 5. The comment appears in the drawer list and is also passed to `onSubmit(payload)`. Each item can be edited or deleted from the list
+
+The reviewer name is saved to `localStorage` after submit and restored the next time the widget starts. Persisting the feedback list itself to `localStorage` is not included yet.
 
 ## Payload
 
@@ -199,7 +201,7 @@ This exposes the webhook URL in the browser, so keep it to disposable testing we
 
 ## Current Boundary
 
-This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload — wire up `endpoint` if you need persistence.
+This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload; only the reviewer name is persisted to `localStorage`. Wire up `endpoint` if you need feedback persistence.
 
 Not included yet:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ PatchLoop は、普通の HTML に `script` tag で埋め込める standalone wi
   window.PatchLoop.init({
     projectId: "patchloop",
     demoId: "plain-html-renewal-review",
-    reviewer: "Kosako",
     endpoint: "http://localhost:4000/feedback",
     showDeliverySettings: true,
     onSubmit(payload) {
@@ -59,7 +58,8 @@ PatchLoop は、普通の HTML に `script` tag で埋め込める standalone wi
 
 - `projectId` (string) — payload に乗せるプロジェクト識別子
 - `demoId` (string) — payload に乗せるデモ識別子
-- `reviewer` (string, optional) — コメントフォームに初期表示する投稿者名
+- `reviewer` (string, optional) — コメントフォームに初期表示する投稿者名。未指定の場合は保存済み reviewer を `localStorage` から復元し、保存値もなければ空欄
+- `reviewerStorageKey` (string, optional) — reviewer 名を保存する `localStorage` key。デフォルトは `patchloop:reviewer`
 - `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — 送信方式。デフォルトは `"receiver"`
 - `endpoint` (string, optional) — payload を `POST` する URL。未設定なら送信しない
 - `slackWebhookUrl` (string, optional) — `deliveryMode: "slack-webhook"` 時にブラウザから直接送る Slack Incoming Webhook URL
@@ -84,8 +84,10 @@ submit のたびに `document` で `patchloop:feedback` が発火し、`event.de
 1. 右端のハンドルを押して drawer を開く
 2. 「コメントモード開始」を押す
 3. 画面上の場所をクリック、または範囲をドラッグする
-4. コメントと投稿者を書いて送信する
+4. コメントと投稿者を書いて送信する。投稿者が空欄の場合は送信できません
 5. drawer の一覧に追加され、`onSubmit(payload)` でも payload を受け取る。送信済みの項目は drawer 内から個別に編集・削除できる
+
+投稿者名は送信後に `localStorage` へ保存され、次回以降の widget 起動時に復元されます。feedback 本体の `localStorage` 永続化はまだ未対応です。
 
 ## Payload
 
@@ -199,7 +201,7 @@ window.PatchLoop.init({
 
 ## 現在の境界
 
-このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。永続化したい場合は `endpoint` 経由で receiver に送ってください。
+このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。投稿者名だけは `localStorage` に保存されます。feedback 本体を永続化したい場合は `endpoint` 経由で receiver に送ってください。
 
 未対応:
 

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -79,7 +79,6 @@
       window.PatchLoop.init({
         projectId: "patchloop",
         demoId: "plain-html-renewal-review",
-        reviewer: "Kosako",
         endpoint: "http://localhost:4000/feedback",
         showDeliverySettings: true,
         onSubmit(payload) {

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -9,6 +9,7 @@
     slackWebhookUrl: "",
     showDeliverySettings: false,
     reviewer: "",
+    reviewerStorageKey: "patchloop:reviewer",
     position: "bottom-right",
     captureScreenshot: true,
     screenshotMaxBytes: 1_200_000,
@@ -29,6 +30,7 @@
 
   function init(options = {}) {
     state.options = { ...DEFAULTS, ...options };
+    state.options.reviewer = initialReviewer(state.options);
     injectStyles();
     renderShell();
     bindGlobalCapture();
@@ -52,6 +54,12 @@
     state.drag = null;
     state.feedbackMarkers.clear();
     state.editingId = null;
+  }
+
+  function initialReviewer(options) {
+    const configured = String(options.reviewer || "").trim();
+    if (configured) return configured;
+    return loadStoredReviewer(options.reviewerStorageKey);
   }
 
   function renderShell() {
@@ -86,8 +94,9 @@
         </label>
         <label>
           投稿者
-          <input data-pl-reviewer value="${escapeHtml(state.options.reviewer)}" placeholder="名前" />
+          <input data-pl-reviewer value="${escapeHtml(state.options.reviewer)}" placeholder="名前" aria-describedby="pl-reviewer-error" />
         </label>
+        <p class="pl-form-error" id="pl-reviewer-error" data-pl-form-error hidden></p>
         <div class="pl-form-actions">
           <button type="button" data-pl-cancel>キャンセル</button>
           <button type="submit">送信</button>
@@ -102,6 +111,7 @@
     root.querySelector("[data-pl-clear]").addEventListener("click", clearPins);
     root.querySelector("[data-pl-cancel]").addEventListener("click", cancelPendingComment);
     root.querySelector("[data-pl-comment]").addEventListener("submit", submitComment);
+    root.querySelector("[data-pl-reviewer]").addEventListener("input", () => clearFormError(root.querySelector("[data-pl-comment]")));
     root.querySelector("[data-pl-list]").addEventListener("click", handleListClick);
     root.querySelector("[data-pl-delivery-settings]")?.addEventListener("input", handleDeliverySettingsInput);
     root.querySelector("[data-pl-delivery-settings]")?.addEventListener("change", handleDeliverySettingsInput);
@@ -272,6 +282,7 @@
   function openCommentForm(point, options = {}) {
     const form = getRoot().querySelector("[data-pl-comment]");
     form.hidden = false;
+    clearFormError(form);
     form.style.left = `${Math.min(point.clientX + 14, window.innerWidth - 340)}px`;
     form.style.top = `${Math.min(point.clientY + 14, window.innerHeight - 250)}px`;
     const commentEl = form.querySelector("[data-pl-comment-text]");
@@ -284,7 +295,9 @@
   }
 
   function closeCommentForm() {
-    getRoot().querySelector("[data-pl-comment]").hidden = true;
+    const form = getRoot().querySelector("[data-pl-comment]");
+    clearFormError(form);
+    form.hidden = true;
     state.pendingTarget = null;
   }
 
@@ -311,19 +324,41 @@
     if (slackField) slackField.hidden = mode !== "slack-webhook";
   }
 
+  function showFormError(form, message) {
+    const errorEl = form?.querySelector("[data-pl-form-error]");
+    if (!errorEl) return;
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+  }
+
+  function clearFormError(form) {
+    const errorEl = form?.querySelector("[data-pl-form-error]");
+    if (!errorEl) return;
+    errorEl.textContent = "";
+    errorEl.hidden = true;
+  }
+
   async function submitComment(event) {
     event.preventDefault();
 
     const root = getRoot();
+    const form = root.querySelector("[data-pl-comment]");
     const comment = root.querySelector("[data-pl-comment-text]").value.trim();
     const reviewer = root.querySelector("[data-pl-reviewer]").value.trim();
     if (!comment) return;
+    if (!reviewer) {
+      showFormError(form, "投稿者名を入力してください。");
+      root.querySelector("[data-pl-reviewer]").focus();
+      return;
+    }
+    clearFormError(form);
 
     if (state.editingId) {
       const target = state.feedback.find((item) => item.id === state.editingId);
       if (target) {
         target.comment = comment;
         target.reviewer = reviewer;
+        saveReviewer(reviewer);
         renderFeedbackList();
       }
       state.editingId = null;
@@ -333,6 +368,7 @@
 
     if (!state.pendingTarget) return;
 
+    saveReviewer(reviewer);
     const payload = buildPayload(comment, reviewer, state.pendingTarget);
     state.feedback.unshift(payload);
     finalizePendingMarker(payload.id);
@@ -552,6 +588,25 @@
       payload.delivery = { ok: false, error: error.message };
     }
     console.info("[PatchLoop] delivery", payload.id, payload.delivery);
+  }
+
+  function loadStoredReviewer(storageKey) {
+    if (!storageKey) return "";
+    try {
+      return String(window.localStorage.getItem(storageKey) || "").trim();
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function saveReviewer(reviewer) {
+    state.options.reviewer = reviewer;
+    if (!state.options.reviewerStorageKey) return;
+    try {
+      window.localStorage.setItem(state.options.reviewerStorageKey, reviewer);
+    } catch (_) {
+      // Storage can be unavailable in privacy-restricted contexts.
+    }
   }
 
   function shouldDeliverFeedback() {
@@ -1135,6 +1190,7 @@
       .pl-comment { position: fixed; z-index: 2147483001; width: min(320px, calc(100vw - 24px)); display: grid; gap: 10px; padding: 14px; background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; box-shadow: 0 22px 70px rgba(20, 33, 29, 0.24); }
       .pl-comment label { display: grid; gap: 6px; color: #65716d; font-size: 12px; font-weight: 800; }
       .pl-comment textarea, .pl-comment input { width: 100%; border: 1px solid #d9e1dd; border-radius: 8px; padding: 9px 10px; color: #14211d; font: inherit; resize: vertical; }
+      .pl-form-error { margin: -2px 0 0; padding: 0; color: #b83d4d; font-size: 12px; font-weight: 800; }
       .pl-form-actions { display: flex; justify-content: flex-end; gap: 8px; }
       .pl-pin { position: absolute; z-index: 2147482999; transform: translate(-50%, -50%); width: 30px; height: 30px; min-width: 30px; min-height: 30px; max-width: 30px; max-height: 30px; box-sizing: border-box; display: grid; place-items: center; padding: 0; line-height: 1; border-radius: 50%; border: 3px solid #fff; background: #d1495b; color: #fff; font: 900 13px/1 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; box-shadow: 0 12px 30px rgba(20, 33, 29, 0.25); cursor: pointer; }
       .pl-selection { position: fixed; z-index: 2147482998; border: 2px solid #d1495b; background: rgba(209, 73, 91, 0.12); border-radius: 6px; pointer-events: none; }


### PR DESCRIPTION
## Summary
- Remove the fixed `reviewer: "Kosako"` value from the plain HTML example so the first reviewer field starts empty
- Require a non-empty reviewer before creating a feedback payload, with an inline form validation message
- Persist the reviewer name to `localStorage` after submit and restore it on the next widget initialization
- Add `reviewerStorageKey` as a configurable option
- Update README / README.en with reviewer validation and persistence behavior

Closes #26

## Validation
- `node --check widget/patchloop-widget.js`
- `node --check server/receive.js`
- `git diff --check`
- Headless Chrome CDP smoke test against `http://127.0.0.1:4175/examples/plain-html/`:
  - initial reviewer value is empty
  - blank reviewer submit shows `投稿者名を入力してください。`
  - blank reviewer submit does not create feedback
  - valid reviewer submit creates feedback with reviewer `Codex`
  - reload restores reviewer `Codex`
  - feedback list itself remains non-persistent after reload
