### PR TITLE
Add download feedback bundles and receiver import

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -33,7 +33,9 @@ script-tag widget:
 - Optional `onSubmit(payload)` callback
 - Optional `endpoint` setting that POSTs payloads to the bundled local receiver
 - Optional Slack Incoming Webhook forwarding from the local receiver with screenshot links, image blocks, and optional file upload
-- Configurable delivery mode for receiver forwarding, direct Slack webhook delivery, or no delivery
+- Download mode that saves a versioned JSON bundle for each feedback item
+- Receiver inbox import for bundles created by download mode
+- Configurable delivery mode for receiver forwarding, direct Slack webhook delivery, download, or no delivery
 
 ## Embeddable Widget
 
@@ -60,7 +62,7 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 - `demoId` (string) — identifier carried in the payload
 - `reviewer` (string, optional) — pre-fills the reviewer field in the comment form. When omitted, the widget restores a saved reviewer from `localStorage`; otherwise the field starts empty
 - `reviewerStorageKey` (string, optional) — `localStorage` key used to persist the reviewer name; defaults to `patchloop:reviewer`
-- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — delivery target; defaults to `"receiver"`
+- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"download"` | `"none"`, optional) — delivery target; defaults to `"receiver"`
 - `endpoint` (string, optional) — URL the widget POSTs each payload to; nothing is sent when omitted
 - `slackWebhookUrl` (string, optional) — Slack Incoming Webhook URL used when `deliveryMode: "slack-webhook"`
 - `showDeliverySettings` (boolean, optional) — show the delivery target controls in the drawer; defaults to `false`
@@ -132,7 +134,9 @@ node server/receive.js
 ```
 
 - Accepts payload at `POST /feedback`, appending to `server/feedback.json` by default
+- Imports download-mode JSON bundles at `POST /import`, storing them in the same inbox format
 - Renders an inbox of received feedback at `GET /`
+- Imports `.patchloop-feedback.json` files from the inbox UI
 - Returns the raw JSON at `GET /feedback.json`
 - Serves saved screenshots from `GET /screenshots/:file`
 - Configurable via `PORT` / `HOST` env (default `127.0.0.1:4000`)
@@ -199,9 +203,49 @@ window.PatchLoop.init({
 
 This exposes the webhook URL in the browser, so keep it to disposable testing webhooks in public environments. Incoming Webhooks cannot send a browser-generated `dataUrl` screenshot as a Slack image or file, so Slack direct mode sends the comment, page, target position, selector, viewport, and screenshot capture status. The screenshot data still remains available in the widget payload and `onSubmit`. To show or upload the generated screenshot in Slack, use receiver mode with `publicBaseUrl` or Slack file upload settings. Direct browser delivery uses `no-cors`, so the response body is not available to the widget.
 
+## Download Mode And Receiver Import
+
+Use `deliveryMode: "download"` to save feedback as a local file without running the receiver or using a Slack webhook.
+
+```js
+window.PatchLoop.init({
+  deliveryMode: "download",
+  showDeliverySettings: true
+});
+```
+
+On submit, the widget downloads `<project>-<demo>-<feedback-id>.patchloop-feedback.json`. The bundle is a single JSON file for now, not a ZIP. The format is versioned.
+
+```json
+{
+  "kind": "patchloop-feedback-bundle",
+  "version": 1,
+  "exportedAt": "2026-06-02T00:00:00.000Z",
+  "projectId": "patchloop",
+  "demoId": "plain-html-renewal-review",
+  "feedback": {
+    "id": "pl_...",
+    "screenshot": {
+      "status": "captured",
+      "dataUrl": "data:image/svg+xml;base64,..."
+    }
+  }
+}
+```
+
+To import a bundle, start the receiver and open the inbox (`http://127.0.0.1:4000/`), then choose the `.patchloop-feedback.json` file under `Import feedback bundle`. To import through the API, post the same JSON to `POST /import`.
+
+```sh
+curl -X POST http://127.0.0.1:4000/import \
+  -H "Content-Type: application/json" \
+  --data-binary @patchloop-feedback.json
+```
+
+The receiver validates the bundle version and payload shape, saves the screenshot `dataUrl` to `server/screenshots/`, and appends the imported feedback to `server/feedback.json`. Imported feedback gets `source: "import"` and `importedAt`. The receiver does not forward imported feedback to Slack; the inbox shows `Slack: skipped`.
+
 ## Current Boundary
 
-This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload; only the reviewer name is persisted to `localStorage`. Wire up `endpoint` if you need feedback persistence.
+This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The drawer list inside the widget is kept in memory only and is cleared on reload; only the reviewer name is persisted to `localStorage`. Use a receiver `endpoint` or download mode if you need to persist or collect feedback.
 
 Not included yet:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ script-tag widget:
 - 任意の `onSubmit(payload)` callback
 - 任意の `endpoint` 設定で payload を receiver に POST
 - ローカル receiver から任意の Slack Incoming Webhook へ、スクショリンク / image block / 任意の file upload 付きで転送
-- 設定または drawer UI から、receiver 経由送信 / Slack webhook 直送 / 送信なしを切り替え
+- Download mode で 1 feedback ごとの versioned JSON bundle を保存
+- receiver inbox から download mode の bundle を import
+- 設定または drawer UI から、receiver 経由送信 / Slack webhook 直送 / download / 送信なしを切り替え
 
 ## 埋め込み Widget
 
@@ -60,7 +62,7 @@ PatchLoop は、普通の HTML に `script` tag で埋め込める standalone wi
 - `demoId` (string) — payload に乗せるデモ識別子
 - `reviewer` (string, optional) — コメントフォームに初期表示する投稿者名。未指定の場合は保存済み reviewer を `localStorage` から復元し、保存値もなければ空欄
 - `reviewerStorageKey` (string, optional) — reviewer 名を保存する `localStorage` key。デフォルトは `patchloop:reviewer`
-- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"none"`, optional) — 送信方式。デフォルトは `"receiver"`
+- `deliveryMode` (`"receiver"` | `"slack-webhook"` | `"download"` | `"none"`, optional) — 送信方式。デフォルトは `"receiver"`
 - `endpoint` (string, optional) — payload を `POST` する URL。未設定なら送信しない
 - `slackWebhookUrl` (string, optional) — `deliveryMode: "slack-webhook"` 時にブラウザから直接送る Slack Incoming Webhook URL
 - `showDeliverySettings` (boolean, optional) — drawer 内に送信先切替 UI を表示するか。デフォルトは `false`
@@ -132,7 +134,9 @@ node server/receive.js
 ```
 
 - `POST /feedback` で payload を受け取り、デフォルトでは `server/feedback.json` に追記します
+- `POST /import` で download mode の JSON bundle を読み込み、通常の inbox と同じ形式で保存します
 - `GET /` で受信した feedback の一覧（inbox）を表示します
+- inbox UI から `.patchloop-feedback.json` を選択して import できます
 - `GET /feedback.json` で raw JSON を返します
 - `GET /screenshots/:file` で保存済み screenshot を返します
 - `PORT` / `HOST` env で変更可能（デフォルトは `127.0.0.1:4000`）
@@ -199,9 +203,49 @@ window.PatchLoop.init({
 
 このモードでは webhook URL がブラウザに見えるため、公開環境では使い捨ての検証用 webhook に限定してください。Incoming Webhook はブラウザ内で生成した `dataUrl` screenshot を Slack image/file として送れないため、Slack direct mode が Slack に送るのはコメント本文・ページ・対象位置・selector・viewport・screenshot 取得ステータスです。widget 内の payload と `onSubmit` には screenshot 情報が残ります。画像そのものを Slack に表示または file upload したい場合は、receiver mode で `publicBaseUrl` / `slackBotToken` / `slackUploadChannelId` を使ってください。ブラウザ直送は `no-cors` で投げるため、成功レスポンスの本文は取得できません。
 
+## Download mode と receiver import
+
+`deliveryMode: "download"` を使うと、receiver や Slack webhook を使わずに feedback をローカルファイルとして保存できます。
+
+```js
+window.PatchLoop.init({
+  deliveryMode: "download",
+  showDeliverySettings: true
+});
+```
+
+送信時に `<project>-<demo>-<feedback-id>.patchloop-feedback.json` が保存されます。この bundle は単一 JSON ファイルで、現時点では ZIP ではありません。形式は versioned です。
+
+```json
+{
+  "kind": "patchloop-feedback-bundle",
+  "version": 1,
+  "exportedAt": "2026-06-02T00:00:00.000Z",
+  "projectId": "patchloop",
+  "demoId": "plain-html-renewal-review",
+  "feedback": {
+    "id": "pl_...",
+    "screenshot": {
+      "status": "captured",
+      "dataUrl": "data:image/svg+xml;base64,..."
+    }
+  }
+}
+```
+
+Import するには receiver を起動し、inbox (`http://127.0.0.1:4000/`) の `Import feedback bundle` から `.patchloop-feedback.json` を選択します。API から送る場合は同じ JSON を `POST /import` に投げます。
+
+```sh
+curl -X POST http://127.0.0.1:4000/import \
+  -H "Content-Type: application/json" \
+  --data-binary @patchloop-feedback.json
+```
+
+receiver は bundle version と payload shape を検証し、screenshot の `dataUrl` を `server/screenshots/` に保存してから `server/feedback.json` に追記します。import した feedback には `source: "import"` / `importedAt` が付きます。Slack への再転送はせず、inbox 上では `Slack: skipped` と表示されます。
+
 ## 現在の境界
 
-このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。投稿者名だけは `localStorage` に保存されます。feedback 本体を永続化したい場合は `endpoint` 経由で receiver に送ってください。
+このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の一覧はメモリ保持のみで、ページをリロードすると消えます。投稿者名だけは `localStorage` に保存されます。feedback 本体を永続化・回収したい場合は `endpoint` 経由で receiver に送るか、download mode で bundle を保存してください。
 
 未対応:
 

--- a/server/receive.js
+++ b/server/receive.js
@@ -21,6 +21,8 @@ const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || config.slackTime
 const SLACK_IMAGE_MODE = normalizeSlackImageMode(process.env.SLACK_IMAGE_MODE || config.slackImageMode || "auto");
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN || config.slackBotToken || "";
 const SLACK_UPLOAD_CHANNEL_ID = process.env.SLACK_UPLOAD_CHANNEL_ID || config.slackUploadChannelId || "";
+const IMPORT_BUNDLE_KIND = "patchloop-feedback-bundle";
+const IMPORT_BUNDLE_VERSION = 1;
 
 let feedback = loadFeedback();
 
@@ -35,6 +37,11 @@ const server = http.createServer((req, res) => {
 
   if (req.method === "POST" && req.url === "/feedback") {
     handlePostFeedback(req, res);
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/import") {
+    handlePostImport(req, res);
     return;
   }
 
@@ -104,31 +111,7 @@ function normalizeSlackImageMode(value) {
 }
 
 function handlePostFeedback(req, res) {
-  let received = 0;
-  const chunks = [];
-  let aborted = false;
-
-  req.on("data", (chunk) => {
-    if (aborted) return;
-    received += chunk.length;
-    if (received > MAX_BODY_BYTES) {
-      aborted = true;
-      respondJson(res, 413, { ok: false, error: "Payload too large" });
-      req.destroy();
-      return;
-    }
-    chunks.push(chunk);
-  });
-
-  req.on("end", async () => {
-    if (aborted) return;
-    let payload;
-    try {
-      payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-    } catch (_) {
-      respondJson(res, 400, { ok: false, error: "Invalid JSON" });
-      return;
-    }
+  readJsonBody(req, res, async (payload) => {
     let screenshot;
     try {
       screenshot = saveScreenshot(payload.screenshot, payload.id);
@@ -155,11 +138,151 @@ function handlePostFeedback(req, res) {
       slack: stored.integrations.slack
     });
   });
+}
+
+function handlePostImport(req, res) {
+  readJsonBody(req, res, async (body) => {
+    let imported;
+    let screenshot;
+    try {
+      imported = normalizeImportedBundle(body);
+      screenshot = saveScreenshot(imported.screenshot, imported.id);
+    } catch (error) {
+      respondJson(res, error.statusCode || 400, { ok: false, error: error.message });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const stored = {
+      ...imported,
+      receivedAt: now,
+      importedAt: now,
+      source: "import",
+      screenshot,
+      integrations: {
+        slack: { status: "skipped", reason: "import" }
+      }
+    };
+
+    feedback.unshift(stored);
+    persist();
+    console.log(`[PatchLoop receiver] imported feedback id=${stored.id || "?"} comment="${truncate(stored.comment || "", 60)}"`);
+    respondJson(res, 201, {
+      ok: true,
+      id: stored.id,
+      count: feedback.length,
+      source: "import"
+    });
+  });
+}
+
+function readJsonBody(req, res, onJson) {
+  let received = 0;
+  const chunks = [];
+  let aborted = false;
+
+  req.on("data", (chunk) => {
+    if (aborted) return;
+    received += chunk.length;
+    if (received > MAX_BODY_BYTES) {
+      aborted = true;
+      respondJson(res, 413, { ok: false, error: "Payload too large" });
+      req.destroy();
+      return;
+    }
+    chunks.push(chunk);
+  });
+
+  req.on("end", async () => {
+    if (aborted) return;
+    let payload;
+    try {
+      payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    } catch (_) {
+      respondJson(res, 400, { ok: false, error: "Invalid JSON" });
+      return;
+    }
+    try {
+      await onJson(payload);
+    } catch (error) {
+      if (!res.headersSent) {
+        respondJson(res, error.statusCode || 500, { ok: false, error: error.message });
+      }
+    }
+  });
 
   req.on("error", (error) => {
     if (aborted) return;
     respondJson(res, 500, { ok: false, error: error.message });
   });
+}
+
+function normalizeImportedBundle(body) {
+  requirePlainObject(body, "Import body");
+
+  let payload;
+  if (body.kind === IMPORT_BUNDLE_KIND) {
+    if (body.version !== IMPORT_BUNDLE_VERSION) {
+      throw httpError(`Unsupported PatchLoop bundle version: ${body.version}`, 400);
+    }
+    payload = body.feedback;
+  } else if (body.feedback) {
+    payload = body.feedback;
+  } else {
+    payload = body;
+  }
+
+  validateFeedbackPayload(payload);
+  const imported = JSON.parse(JSON.stringify(payload));
+  delete imported.delivery;
+  delete imported.integrations;
+  delete imported.receivedAt;
+  delete imported.importedAt;
+  delete imported.source;
+  return imported;
+}
+
+function validateFeedbackPayload(payload) {
+  requirePlainObject(payload, "Feedback payload");
+  requireNonEmptyString(payload.id, "feedback.id");
+  requireNonEmptyString(payload.comment, "feedback.comment");
+  requireNonEmptyString(payload.reviewer, "feedback.reviewer");
+  requirePlainObject(payload.page, "feedback.page");
+  requirePlainObject(payload.target, "feedback.target");
+  requirePlainObject(payload.environment, "feedback.environment");
+
+  if (payload.projectId != null) requireString(payload.projectId, "feedback.projectId");
+  if (payload.demoId != null) requireString(payload.demoId, "feedback.demoId");
+  if (payload.createdAt != null) requireString(payload.createdAt, "feedback.createdAt");
+  if (payload.page.url != null) requireString(payload.page.url, "feedback.page.url");
+  if (payload.page.title != null) requireString(payload.page.title, "feedback.page.title");
+
+  if (!["point", "area"].includes(payload.target.kind)) {
+    throw httpError("feedback.target.kind must be point or area", 400);
+  }
+  if (payload.target.selector != null) requireString(payload.target.selector, "feedback.target.selector");
+  if (payload.target.text != null) requireString(payload.target.text, "feedback.target.text");
+  if (payload.target.area != null) requirePlainObject(payload.target.area, "feedback.target.area");
+  if (payload.screenshot != null) requirePlainObject(payload.screenshot, "feedback.screenshot");
+}
+
+function requirePlainObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw httpError(`${label} must be an object`, 400);
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string") {
+    throw httpError(`${label} must be a string`, 400);
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  requireString(value, label);
+  if (!value.trim()) {
+    throw httpError(`${label} must not be empty`, 400);
+  }
 }
 
 function handleGetInbox(req, res) {
@@ -728,6 +851,8 @@ function renderInbox(items) {
     const reviewer = escapeHtml(item.reviewer || "");
     const createdAt = escapeHtml(item.createdAt || "");
     const receivedAt = escapeHtml(item.receivedAt || "");
+    const source = escapeHtml(item.source || "receiver");
+    const importedAt = escapeHtml(item.importedAt || "");
     const viewport = env.viewport
       ? `${env.viewport.width}×${env.viewport.height}`
       : "";
@@ -745,8 +870,10 @@ function renderInbox(items) {
           <div><dt>Title</dt><dd>${pageTitle}</dd></div>
           <div><dt>Selector</dt><dd><code>${selector}</code></dd></div>
           <div><dt>Viewport</dt><dd>${escapeHtml(viewport)}</dd></div>
+          <div><dt>Source</dt><dd>${source}</dd></div>
           <div><dt>Slack</dt><dd>${escapeHtml(formatSlackStatus(slack))}</dd></div>
           <div><dt>Created</dt><dd>${createdAt}</dd></div>
+          ${importedAt ? `<div><dt>Imported</dt><dd>${importedAt}</dd></div>` : ""}
         </dl>
         <details>
           <summary>raw payload</summary>
@@ -769,6 +896,14 @@ function renderInbox(items) {
     .meta { color: #65716d; margin-bottom: 24px; font-size: 13px; }
     .meta a { color: #0f7b63; }
     .empty { color: #65716d; }
+    .import-panel { display: flex; align-items: center; justify-content: space-between; gap: 14px; flex-wrap: wrap; margin: 0 0 18px; padding: 14px 16px; border: 1px solid #d9e1dd; border-radius: 8px; background: #fff; }
+    .import-panel h2 { margin: 0; font-size: 15px; }
+    .import-panel p { margin: 4px 0 0; color: #65716d; font-size: 12px; }
+    .import-form { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .import-form input { max-width: min(360px, 100%); }
+    .import-form button { min-height: 34px; border: 1px solid #0f7b63; border-radius: 6px; background: #0f7b63; color: #fff; padding: 0 12px; font: inherit; font-size: 13px; font-weight: 800; cursor: pointer; }
+    .import-status { min-width: 160px; color: #65716d; font-size: 12px; }
+    .import-status[data-state="error"] { color: #b83d4d; font-weight: 800; }
     .card { background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; box-shadow: 0 4px 12px rgba(20, 33, 29, 0.05); }
     .card header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 12px; color: #65716d; }
     .kind { padding: 2px 8px; border-radius: 999px; font-weight: 800; color: #fff; font-size: 11px; text-transform: uppercase; }
@@ -796,9 +931,67 @@ function renderInbox(items) {
 <body>
   <h1>PatchLoop Inbox</h1>
   <p class="meta">${items.length} feedback received · <a href="/feedback.json">raw JSON</a></p>
+  ${renderImportPanel()}
   ${items.length === 0 ? '<p class="empty">まだフィードバックはありません。widget からコメントを送ると、ここに表示されます。</p>' : cards.join("")}
+  ${renderImportScript()}
 </body>
 </html>`;
+}
+
+function renderImportPanel() {
+  return `
+  <section class="import-panel">
+    <div>
+      <h2>Import feedback bundle</h2>
+      <p>Download mode で保存した .patchloop-feedback.json を読み込みます。</p>
+    </div>
+    <form class="import-form" data-import-form>
+      <input type="file" accept=".json,application/json" data-import-file />
+      <button type="submit">Import</button>
+      <span class="import-status" data-import-status></span>
+    </form>
+  </section>`;
+}
+
+function renderImportScript() {
+  return `<script>
+(() => {
+  const form = document.querySelector("[data-import-form]");
+  if (!form) return;
+  const input = form.querySelector("[data-import-file]");
+  const status = form.querySelector("[data-import-status]");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    status.dataset.state = "";
+    const file = input.files && input.files[0];
+    if (!file) {
+      status.dataset.state = "error";
+      status.textContent = "Choose a JSON bundle first.";
+      return;
+    }
+
+    status.textContent = "Importing...";
+    try {
+      const text = await file.text();
+      const response = await fetch("/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: text
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(result.error || "Import failed");
+      }
+      status.textContent = "Imported " + (result.id || "feedback") + ". Reloading...";
+      window.location.reload();
+    } catch (error) {
+      status.dataset.state = "error";
+      status.textContent = error.message;
+    }
+  });
+})();
+</script>`;
 }
 
 function renderScreenshotPreview(screenshot) {

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -16,6 +16,9 @@
     onSubmit: null
   };
 
+  const EXPORT_KIND = "patchloop-feedback-bundle";
+  const EXPORT_VERSION = 1;
+
   const state = {
     options: { ...DEFAULTS },
     active: false,
@@ -129,6 +132,7 @@
               <select data-pl-delivery-mode>
                 <option value="receiver"${state.options.deliveryMode === "receiver" ? " selected" : ""}>Receiver</option>
                 <option value="slack-webhook"${state.options.deliveryMode === "slack-webhook" ? " selected" : ""}>Slack direct</option>
+                <option value="download"${state.options.deliveryMode === "download" ? " selected" : ""}>Download</option>
                 <option value="none"${state.options.deliveryMode === "none" ? " selected" : ""}>送信なし</option>
               </select>
             </label>
@@ -611,17 +615,78 @@
 
   function shouldDeliverFeedback() {
     if (state.options.deliveryMode === "none") return false;
+    if (state.options.deliveryMode === "download") return true;
     if (state.options.deliveryMode === "slack-webhook") return Boolean(state.options.slackWebhookUrl);
     return Boolean(state.options.endpoint);
   }
 
   async function deliverFeedback(payload) {
+    if (state.options.deliveryMode === "download") {
+      downloadFeedbackBundle(payload);
+      return;
+    }
+
     if (state.options.deliveryMode === "slack-webhook") {
       await postSlackWebhook(payload);
       return;
     }
 
     await postFeedback(payload);
+  }
+
+  function downloadFeedbackBundle(payload) {
+    try {
+      const bundle = buildFeedbackBundle(payload);
+      const json = JSON.stringify(bundle, null, 2);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = feedbackBundleFileName(payload);
+      link.style.display = "none";
+      document.body.append(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+      payload.delivery = {
+        ok: true,
+        status: "downloaded",
+        target: "download",
+        fileName: link.download
+      };
+    } catch (error) {
+      payload.delivery = {
+        ok: false,
+        target: "download",
+        error: error.message
+      };
+    }
+    console.info("[PatchLoop] delivery", payload.id, payload.delivery);
+  }
+
+  function buildFeedbackBundle(payload) {
+    return {
+      kind: EXPORT_KIND,
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      projectId: payload.projectId || "",
+      demoId: payload.demoId || "",
+      feedback: payload
+    };
+  }
+
+  function feedbackBundleFileName(payload) {
+    const project = safeFilePart(payload.projectId || "patchloop");
+    const demo = safeFilePart(payload.demoId || "feedback");
+    const id = safeFilePart(payload.id || Date.now());
+    return `${project}-${demo}-${id}.patchloop-feedback.json`;
+  }
+
+  function safeFilePart(value) {
+    return String(value || "feedback")
+      .replace(/[^a-zA-Z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "feedback";
   }
 
   async function postSlackWebhook(payload) {
@@ -877,8 +942,8 @@
         const kind = (item.target && item.target.kind) || "point";
         const delivery = item.delivery
           ? item.delivery.ok
-            ? '<span class="pl-feedback-status pl-feedback-status-ok" title="delivered">✓</span>'
-            : '<span class="pl-feedback-status pl-feedback-status-fail" title="delivery failed">✗</span>'
+            ? `<span class="pl-feedback-status pl-feedback-status-ok" title="${escapeHtml(deliveryStatusText(item.delivery))}">✓</span>`
+            : `<span class="pl-feedback-status pl-feedback-status-fail" title="${escapeHtml(deliveryStatusText(item.delivery))}">✗</span>`
           : "";
         return `
           <article class="pl-feedback-item" data-feedback-id="${escapeHtml(item.id)}">
@@ -895,6 +960,20 @@
         `;
       })
       .join("");
+  }
+
+  function deliveryStatusText(delivery) {
+    if (!delivery) return "";
+    if (delivery.target === "download") {
+      if (delivery.ok) return `downloaded ${delivery.fileName || ""}`.trim();
+      return `download failed: ${delivery.error || "unknown error"}`;
+    }
+    if (delivery.target === "slack-webhook") {
+      if (delivery.ok) return "sent to Slack direct";
+      return `Slack direct failed: ${delivery.error || "unknown error"}`;
+    }
+    if (delivery.ok) return `delivered ${delivery.status || ""}`.trim();
+    return `delivery failed: ${delivery.error || delivery.status || "unknown error"}`;
   }
 
   function renumberMarkers() {


### PR DESCRIPTION
## Summary

- Add widget download delivery mode that saves one versioned JSON bundle per feedback item
- Add receiver `POST /import` and inbox import UI for `.patchloop-feedback.json` bundles
- Document download mode and receiver import in Japanese and English READMEs

## Verification

- `node --check widget/patchloop-widget.js`
- `node --check server/receive.js`
- `git diff --check`
- Smoke-tested `POST /import` with a temporary receiver store and screenshot directory
- Smoke-tested the browser flow: select `Download`, submit feedback, and confirm the feedback item shows a downloaded bundle status

Closes #25
