### PR TITLE
Reload 後の marker 復元を pixel 値優先にする

### DIFF
--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -966,34 +966,22 @@
     return point ? addPin(point) : null;
   }
 
+  // Restore prefers stored document pixels over document-size percentages:
+  // the document height can differ between save and reload (dynamic content),
+  // which shifts every percentage-resolved position. Percentages remain as a
+  // fallback for stored feedback that lacks pixel values.
   function pointFromStoredTarget(target) {
-    const documentWidth = Math.max(document.documentElement.scrollWidth, window.innerWidth, 1);
-    const documentHeight = Math.max(document.documentElement.scrollHeight, window.innerHeight, 1);
-    const pageX = numberOrNull(target.documentX) != null
-      ? (numberOrNull(target.documentX) / 100) * documentWidth
-      : numberOrNull(target.pageX);
-    const pageY = numberOrNull(target.documentY) != null
-      ? (numberOrNull(target.documentY) / 100) * documentHeight
-      : numberOrNull(target.pageY);
+    const pageX = numberOrNull(target.pageX) ?? documentPercentToPxX(target.documentX);
+    const pageY = numberOrNull(target.pageY) ?? documentPercentToPxY(target.documentY);
     if (pageX == null || pageY == null) return null;
     return { pageX, pageY };
   }
 
   function rectFromStoredArea(area) {
-    const documentWidth = Math.max(document.documentElement.scrollWidth, window.innerWidth, 1);
-    const documentHeight = Math.max(document.documentElement.scrollHeight, window.innerHeight, 1);
-    const pageLeftPx = numberOrNull(area.documentX) != null
-      ? (numberOrNull(area.documentX) / 100) * documentWidth
-      : numberOrNull(area.pageX);
-    const pageTopPx = numberOrNull(area.documentY) != null
-      ? (numberOrNull(area.documentY) / 100) * documentHeight
-      : numberOrNull(area.pageY);
-    const widthPx = numberOrNull(area.documentWidth) != null
-      ? (numberOrNull(area.documentWidth) / 100) * documentWidth
-      : numberOrNull(area.clientWidth);
-    const heightPx = numberOrNull(area.documentHeight) != null
-      ? (numberOrNull(area.documentHeight) / 100) * documentHeight
-      : numberOrNull(area.clientHeight);
+    const pageLeftPx = numberOrNull(area.pageX) ?? documentPercentToPxX(area.documentX);
+    const pageTopPx = numberOrNull(area.pageY) ?? documentPercentToPxY(area.documentY);
+    const widthPx = numberOrNull(area.clientWidth) ?? documentPercentToPxX(area.documentWidth);
+    const heightPx = numberOrNull(area.clientHeight) ?? documentPercentToPxY(area.documentHeight);
 
     if (pageLeftPx == null || pageTopPx == null || widthPx == null || heightPx == null) return null;
     return {
@@ -1002,6 +990,18 @@
       widthPx: Math.max(1, widthPx),
       heightPx: Math.max(1, heightPx)
     };
+  }
+
+  function documentPercentToPxX(value) {
+    const percent = numberOrNull(value);
+    if (percent == null) return null;
+    return (percent / 100) * Math.max(document.documentElement.scrollWidth, window.innerWidth, 1);
+  }
+
+  function documentPercentToPxY(value) {
+    const percent = numberOrNull(value);
+    if (percent == null) return null;
+    return (percent / 100) * Math.max(document.documentElement.scrollHeight, window.innerHeight, 1);
   }
 
   function removeCommittedMarkers() {


### PR DESCRIPTION
## 概要

Closes #34

feedback 送信時と reload 後で document の高さが違うと、`documentX/Y`（document サイズ %）基準の復元位置がずれる問題の修正です。復元時は保存済みの pixel 値（`pageX/Y`・`clientWidth/Height`）を優先し、% は pixel 値を持たない古い保存データ向けの fallback に降格しました。

## 変更内容

- `pointFromStoredTarget` / `rectFromStoredArea`: pixel 優先・% fallback に変更
- % → px 変換を `documentPercentToPxX/Y` ヘルパーに切り出し

`widget/patchloop-widget.js` のみ、+22/-22 行。payload 形式・保存形式に変更はありません。

## 動作確認

issue #34 の再現手順を headless Chrome + CDP で実行:

1. point feedback 送信（デモページの `<pre>` が payload を表示して document が 2300px に伸びる）
2. 「拡張パイプライン」パネル上に area feedback を送信
3. reload（`<pre>` が空に戻り document は 1213px に縮む = 1087px の変動）

結果: **pin / area とも drift 0px**、area は reload 後もパネル内に収まることを確認（修正前は約 200px 上にずれていた）。`npm run check`（lint + テスト 4 件）もパス。

## スコープ外

viewport 幅が変わってページがリフローするケースは pixel でも % でも追従できません。必要になったら `target.selector` による再アンカーを別 issue で検討してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)