### PR TITLE
コメント入力の操作感改善: 連続コメントモードと Cmd+Enter 送信

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -42,6 +42,8 @@ script-tag widget:
 - Comment mode toggle in the drawer header (active state colours the handle)
 - Click-to-pin location capture and drag-to-select area capture
 - Draft markers that take their final sequential number on submit
+- Comment mode stays active after submit so several spots can be annotated in a row
+- Cmd+Enter (Ctrl+Enter on Windows) submits the comment form
 - Target element outline while a draft is pending
 - Per-feedback comment list with reviewer, kind, comment, and delivery status
 - Hover tooltip on markers showing the comment (disabled in feedback mode)
@@ -107,7 +109,7 @@ PatchLoop includes a standalone widget that can be embedded into a normal HTML p
 1. Click the right-edge handle to open the drawer
 2. Start comment mode
 3. Click a point or drag an area on the page
-4. Write a comment and reviewer name, then submit. Feedback cannot be submitted while the reviewer is blank
+4. Write a comment and reviewer name, then submit (Cmd+Enter / Ctrl+Enter also works). Feedback cannot be submitted while the reviewer is blank. Comment mode stays active after submit; end it with the mode button in the drawer header
 5. The comment appears in the drawer list and is also passed to `onSubmit(payload)`. Each item can be edited or deleted from the list
 
 The reviewer name is saved to `localStorage` after submit and restored the next time the widget starts. The feedback list is also saved to `localStorage` by default and restored after reloads on the same project / demo / page URL, including pins and area overlays. The drawer's clear action removes both visible markers and saved feedback. Set `persistFeedback: false` for memory-only behavior.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ script-tag widget:
 - ドロワーヘッダーのコメントモード切り替え（モード ON 中はハンドルが赤くなる）
 - クリックで点キャプチャ、ドラッグで範囲キャプチャ
 - 送信前はドラフト表示、送信時に 1, 2, 3 と確定番号が振られる
+- 送信後もコメントモードは継続し、連続でコメントできる
+- コメント入力中は Cmd+Enter（Windows は Ctrl+Enter）で送信
 - ドラフト中、対象要素にダッシュドラインの outline
 - ドロワー内のコメント一覧（番号 / kind / reviewer / 本文 / 配送ステータス）
 - マーカーホバーでコメントのツールチップ表示（feedback モード中は無効）
@@ -107,7 +109,7 @@ submit のたびに `document` で `patchloop:feedback` が発火し、`event.de
 1. 右端のハンドルを押して drawer を開く
 2. 「コメントモード開始」を押す
 3. 画面上の場所をクリック、または範囲をドラッグする
-4. コメントと投稿者を書いて送信する。投稿者が空欄の場合は送信できません
+4. コメントと投稿者を書いて送信する。Cmd+Enter（Windows は Ctrl+Enter）でも送信できます。投稿者が空欄の場合は送信できません。コメントモードは送信後も継続するので、終了するには「コメントモード終了」を押します
 5. drawer の一覧に追加され、`onSubmit(payload)` でも payload を受け取る。送信済みの項目は drawer 内から個別に編集・削除できる
 
 投稿者名は送信後に `localStorage` へ保存され、次回以降の widget 起動時に復元されます。feedback list もデフォルトで `localStorage` に保存され、同じ project / demo / page URL の reload 後に drawer list と pin / area overlay が復元されます。drawer の「フィードバックを消す」は、表示中の marker と保存済み feedback の両方を削除します。永続化を使わず memory-only にしたい場合は `persistFeedback: false` を指定してください。

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -118,6 +118,7 @@
     root.querySelector("[data-pl-clear]").addEventListener("click", clearPins);
     root.querySelector("[data-pl-cancel]").addEventListener("click", cancelPendingComment);
     root.querySelector("[data-pl-comment]").addEventListener("submit", submitComment);
+    root.querySelector("[data-pl-comment]").addEventListener("keydown", handleCommentKeydown);
     root.querySelector("[data-pl-reviewer]").addEventListener("input", () => clearFormError(root.querySelector("[data-pl-comment]")));
     root.querySelector("[data-pl-list]").addEventListener("click", handleListClick);
     root.querySelector("[data-pl-delivery-settings]")?.addEventListener("input", handleDeliverySettingsInput);
@@ -309,6 +310,12 @@
     state.pendingTarget = null;
   }
 
+  function handleCommentKeydown(event) {
+    if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
+    event.preventDefault();
+    event.currentTarget.requestSubmit();
+  }
+
   function handleDeliverySettingsInput() {
     const root = getRoot();
     if (!root) return;
@@ -385,7 +392,6 @@
     renderFeedbackList();
     expandPanel();
     closeCommentForm();
-    setFeedbackMode(false);
 
     document.dispatchEvent(new CustomEvent("patchloop:feedback", { detail: payload }));
 


### PR DESCRIPTION
## 概要

Closes #37

ユーザー FB の 2 点を実装します。

## 変更内容

- **連続コメント**: 送信後に `setFeedbackMode(false)` を呼ばないようにし、コメントモードを継続。終了は従来通りヘッダーの「コメントモード終了」ボタンで明示的に行う
- **Cmd+Enter 送信**: コメントフォームに keydown handler を追加。`Cmd+Enter`（Windows は `Ctrl+Enter`）で submit。素の Enter は従来通り textarea 内の改行
- README 日英の機能一覧・基本操作を更新

`widget/patchloop-widget.js` +9/-3、README 日英 +4。

## 動作確認（headless Chrome + CDP、実キーイベント）

- Cmd+Enter で 1 件目を送信 → 送信後も `aria-pressed=true`（モード継続）
- モードボタンを触らずにそのまま 2 件目・3 件目を作成・送信できる
- textarea で素の Enter → 送信されず改行のみ挿入される
- 「コメントモード終了」ボタンで従来通りモード終了
- `npm run check`（lint + テスト 4 件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)