### PR TITLE
Screenshot capture 時に media query と viewport 単位を解決する

### DIFF
--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -509,7 +509,7 @@
     const background = bodyStyle.backgroundColor || "#ffffff";
     const color = bodyStyle.color || "#14211d";
     const font = bodyStyle.font || bodyStyle.fontFamily || "system-ui, sans-serif";
-    const styles = `${collectReadableStyles()}\n* { box-sizing: border-box; }\n`;
+    const styles = `${freezeViewportUnits(collectReadableStyles(), width, height)}\n* { box-sizing: border-box; }\n`;
     const overlayMarkup = renderScreenshotOverlay(overlay);
 
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -530,17 +530,64 @@
 </svg>`;
   }
 
+  // Media queries inside the snapshot re-evaluate against the SVG's rendered
+  // size (e.g. a scaled-down inbox preview), reflowing the clone away from the
+  // captured layout while overlay coordinates stay fixed. Resolve media
+  // conditions at capture time instead: inline the rules that match the
+  // current viewport and drop the rest, so the snapshot keeps the captured
+  // layout at any display size.
   function collectReadableStyles() {
     const chunks = [];
     Array.from(document.styleSheets).forEach((sheet) => {
       try {
         if (sheet.ownerNode?.dataset?.patchloopStyle) return;
-        chunks.push(Array.from(sheet.cssRules || []).map((rule) => rule.cssText).join("\n"));
+        if (sheet.media && sheet.media.mediaText && !window.matchMedia(sheet.media.mediaText).matches) return;
+        const flattened = flattenRulesForSnapshot(sheet.cssRules);
+        if (flattened) chunks.push(flattened);
       } catch (_) {
         // Cross-origin stylesheets cannot be read. The snapshot still includes DOM and overlay context.
       }
     });
     return chunks.join("\n");
+  }
+
+  // Viewport units re-resolve against the rendered size just like media
+  // queries do, so freeze them to the captured viewport in pixels.
+  function freezeViewportUnits(cssText, width, height) {
+    return cssText.replace(/(-?\d*\.?\d+)(?:[dsl])?v(w|h|min|max)\b/g, (match, number, axis) => {
+      const value = Number(number);
+      if (!Number.isFinite(value)) return match;
+      const base = axis === "w"
+        ? width
+        : axis === "h"
+          ? height
+          : axis === "min" ? Math.min(width, height) : Math.max(width, height);
+      return `${(value * base) / 100}px`;
+    });
+  }
+
+  function flattenRulesForSnapshot(rules) {
+    return Array.from(rules || [])
+      .map((rule) => {
+        if (rule.styleSheet) {
+          // @import: inline the imported sheet, honoring its media list.
+          const media = rule.media && rule.media.mediaText;
+          if (media && !window.matchMedia(media).matches) return "";
+          try {
+            return flattenRulesForSnapshot(rule.styleSheet.cssRules);
+          } catch (_) {
+            return "";
+          }
+        }
+        if (rule.media) {
+          return window.matchMedia(rule.media.mediaText).matches
+            ? flattenRulesForSnapshot(rule.cssRules)
+            : "";
+        }
+        return rule.cssText;
+      })
+      .filter(Boolean)
+      .join("\n");
   }
 
   function screenshotOverlayFor(target) {


### PR DESCRIPTION
## 概要

Closes #36

screenshot SVG に埋め込んだ CSS が表示サイズで再評価され、縮小 preview（inbox / Slack）でモバイルレイアウトに reflow して marker overlay とずれる問題の修正です。

## 変更内容（`widget/patchloop-widget.js` のみ）

- **media query の capture 時解決**: `collectReadableStyles` で `CSSMediaRule` を `matchMedia` で評価し、capture 時の viewport に一致するルールの中身だけを media 条件なしで inline 展開。不一致ルールは除去
- **@import の inline 化**: import された stylesheet も同様に展開（media list を尊重）。副次効果として、外部読み込みが禁止される SVG-as-image 内でも import 先のスタイルが効くようになります
- **viewport 単位の固定**: 調査中に同根の問題を発見 — `vw/vh/vmin/vmax`（dvh 等含む）も表示サイズで再解決されるため（デモ CSS の `calc(100vw - 36px)` で再現）、capture 時の viewport サイズで px に変換して凍結

## 動作確認（headless Chrome + CDP）

1. 1280px viewport でデモページから feedback を送信
2. 保存された SVG に `@media` が含まれず、デスクトップ用ルールが inline 化されていることを確認
3. SVG を直接開く → capture 時と同一のデスクトップレイアウト + marker 正位置
4. **inbox を 700px viewport で表示**（issue の再現条件）→ preview がデスクトップレイアウトの縮小として描画され、見出しの折り返しも元画面と同一、marker はクリック位置に正確に乗る（修正前はモバイル reflow でずれていた）
5. 700px で capture した場合は 700px のレイアウトが固定されることも確認（capture 時 viewport への追従）
6. `npm run check` パス

## 制限

- cross-origin stylesheet は従来通り読めないためスキップ（挙動不変）
- container query は未対応（デモでは未使用。必要になったら別 issue で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)