### PR TITLE
Inbox に検索・フィルタと triage status 管理を追加する

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -159,6 +159,9 @@ node server/receive.js
 - Accepts payload at `POST /feedback`, appending to `server/feedback.json` by default
 - Imports download-mode JSON bundles at `POST /import`, storing them in the same inbox format
 - Renders an inbox of received feedback at `GET /`
+- The inbox has text search plus status / kind / reviewer / source / Slack filters
+- Each feedback has a triage status (`new` / `accepted` / `fixed` / `ignored`) editable from the card; statuses persist to `server/feedback.json`
+- `POST /feedback/:id/status` updates the status via the API (body: `{"status": "accepted"}`)
 - Imports `.patchloop-feedback.json` files from the inbox UI
 - Returns the raw JSON at `GET /feedback.json`
 - Serves saved screenshots from `GET /screenshots/:file`

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ node server/receive.js
 - `POST /feedback` で payload を受け取り、デフォルトでは `server/feedback.json` に追記します
 - `POST /import` で download mode の JSON bundle を読み込み、通常の inbox と同じ形式で保存します
 - `GET /` で受信した feedback の一覧（inbox）を表示します
+- inbox にはテキスト検索と status / kind / reviewer / source / Slack の絞り込みがあります
+- 各 feedback には triage status（`new` / `accepted` / `fixed` / `ignored`）があり、card 上の select から変更できます。status は `server/feedback.json` に永続化されます
+- `POST /feedback/:id/status` で API からも status を更新できます（body は `{"status": "accepted"}` 形式）
 - inbox UI から `.patchloop-feedback.json` を選択して import できます
 - `GET /feedback.json` で raw JSON を返します
 - `GET /screenshots/:file` で保存済み screenshot を返します

--- a/server/receive.js
+++ b/server/receive.js
@@ -23,6 +23,7 @@ const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN || config.slackBotToken || "
 const SLACK_UPLOAD_CHANNEL_ID = process.env.SLACK_UPLOAD_CHANNEL_ID || config.slackUploadChannelId || "";
 const IMPORT_BUNDLE_KIND = "patchloop-feedback-bundle";
 const IMPORT_BUNDLE_VERSION = 1;
+const FEEDBACK_STATUSES = ["new", "accepted", "fixed", "ignored"];
 
 let feedback = loadFeedback();
 
@@ -42,6 +43,12 @@ const server = http.createServer((req, res) => {
 
   if (req.method === "POST" && req.url === "/import") {
     handlePostImport(req, res);
+    return;
+  }
+
+  const statusMatch = req.method === "POST" && /^\/feedback\/([^/]+)\/status$/.exec(req.url);
+  if (statusMatch) {
+    handlePostStatus(req, res, decodeURIComponent(statusMatch[1]));
     return;
   }
 
@@ -174,6 +181,27 @@ function handlePostImport(req, res) {
       count: feedback.length,
       source: "import"
     });
+  });
+}
+
+function handlePostStatus(req, res, id) {
+  readJsonBody(req, res, async (body) => {
+    const status = body && body.status;
+    if (!FEEDBACK_STATUSES.includes(status)) {
+      respondJson(res, 400, { ok: false, error: `status must be one of: ${FEEDBACK_STATUSES.join(", ")}` });
+      return;
+    }
+
+    const item = feedback.find((entry) => entry.id === id);
+    if (!item) {
+      respondJson(res, 404, { ok: false, error: `Unknown feedback id: ${id}` });
+      return;
+    }
+
+    item.status = status;
+    item.statusUpdatedAt = new Date().toISOString();
+    persist();
+    respondJson(res, 200, { ok: true, id, status });
   });
 }
 
@@ -837,6 +865,10 @@ function present(value) {
   return value === undefined || value === null || value === "" ? "?" : value;
 }
 
+function feedbackStatusOf(item) {
+  return FEEDBACK_STATUSES.includes(item.status) ? item.status : "new";
+}
+
 function renderInbox(items) {
   const cards = items.map((item) => {
     const target = item.target || {};
@@ -854,14 +886,24 @@ function renderInbox(items) {
     const receivedAt = escapeHtml(item.receivedAt || "");
     const source = escapeHtml(item.source || "receiver");
     const importedAt = escapeHtml(item.importedAt || "");
+    const status = feedbackStatusOf(item);
+    const slackStatus = escapeHtml((slack && slack.status) || "unknown");
+    const searchText = escapeHtml([item.comment, item.reviewer, target.selector, page.url, page.title, item.id]
+      .filter(Boolean).join(" ").toLowerCase());
+    const statusOptions = FEEDBACK_STATUSES
+      .map((value) => `<option value="${value}"${value === status ? " selected" : ""}>${value}</option>`)
+      .join("");
     const viewport = env.viewport
       ? `${env.viewport.width}×${env.viewport.height}`
       : "";
     return `
-      <article class="card">
+      <article class="card" data-card data-status="${status}" data-kind="${kind}" data-reviewer="${reviewer}" data-source="${source}" data-slack="${slackStatus}" data-search="${searchText}">
         <header>
           <span class="kind kind-${kind}">${kind}</span>
           <span class="reviewer">${reviewer || "(no name)"}</span>
+          <label class="status-control">
+            <select data-status-select data-feedback-id="${escapeHtml(item.id || "")}">${statusOptions}</select>
+          </label>
           <time>${receivedAt}</time>
         </header>
         <p class="comment">${comment}</p>
@@ -905,8 +947,17 @@ function renderInbox(items) {
     .import-form button { min-height: 34px; border: 1px solid #0f7b63; border-radius: 6px; background: #0f7b63; color: #fff; padding: 0 12px; font: inherit; font-size: 13px; font-weight: 800; cursor: pointer; }
     .import-status { min-width: 160px; color: #65716d; font-size: 12px; }
     .import-status[data-state="error"] { color: #b83d4d; font-weight: 800; }
-    .card { background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; box-shadow: 0 4px 12px rgba(20, 33, 29, 0.05); }
+    .filter-panel { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 0 0 18px; padding: 12px 16px; border: 1px solid #d9e1dd; border-radius: 8px; background: #fff; }
+    .filter-panel input[type="search"] { flex: 1; min-width: 220px; min-height: 32px; border: 1px solid #d9e1dd; border-radius: 6px; padding: 4px 10px; font: inherit; font-size: 13px; }
+    .filter-panel select { min-height: 32px; border: 1px solid #d9e1dd; border-radius: 6px; background: #fff; padding: 4px 6px; font: inherit; font-size: 12px; color: #14211d; }
+    .filter-count { color: #65716d; font-size: 12px; min-width: 70px; text-align: right; margin-left: auto; }
+    .card { background: #fff; border: 1px solid #d9e1dd; border-left: 4px solid #8a9590; border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; box-shadow: 0 4px 12px rgba(20, 33, 29, 0.05); }
+    .card[data-status="new"] { border-left-color: #8a9590; }
+    .card[data-status="accepted"] { border-left-color: #0f7b63; }
+    .card[data-status="fixed"] { border-left-color: #2c6fb0; }
+    .card[data-status="ignored"] { border-left-color: #c2c9c5; opacity: 0.72; }
     .card header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 12px; color: #65716d; }
+    .status-control select { min-height: 26px; border: 1px solid #d9e1dd; border-radius: 999px; background: #f7f8f5; padding: 2px 8px; font: inherit; font-size: 11px; font-weight: 800; color: #14211d; cursor: pointer; }
     .kind { padding: 2px 8px; border-radius: 999px; font-weight: 800; color: #fff; font-size: 11px; text-transform: uppercase; }
     .kind-point { background: #0f7b63; }
     .kind-area { background: #d1495b; }
@@ -933,8 +984,11 @@ function renderInbox(items) {
   <h1>PatchLoop Inbox</h1>
   <p class="meta">${items.length} feedback received · <a href="/feedback.json">raw JSON</a></p>
   ${renderImportPanel()}
+  ${items.length === 0 ? "" : renderFilterPanel(items)}
   ${items.length === 0 ? '<p class="empty">まだフィードバックはありません。widget からコメントを送ると、ここに表示されます。</p>' : cards.join("")}
+  <p class="empty" data-filter-empty hidden>絞り込みに一致する feedback はありません。</p>
   ${renderImportScript()}
+  ${renderTriageScript()}
 </body>
 </html>`;
 }
@@ -952,6 +1006,84 @@ function renderImportPanel() {
       <span class="import-status" data-import-status></span>
     </form>
   </section>`;
+}
+
+function renderFilterPanel(items) {
+  const optionList = (values, allLabel) => [`<option value="">${allLabel}</option>`]
+    .concat(values.map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`))
+    .join("");
+  const unique = (mapper) => Array.from(new Set(items.map(mapper).filter(Boolean))).sort();
+  const reviewers = unique((item) => item.reviewer || "");
+  const sources = unique((item) => item.source || "receiver");
+  const slackStatuses = unique((item) => (item.integrations && item.integrations.slack && item.integrations.slack.status) || "unknown");
+
+  return `
+  <section class="filter-panel" data-filter-panel>
+    <input type="search" placeholder="検索（コメント / reviewer / selector / URL）" data-filter-text />
+    <select data-filter-key="status">${optionList(FEEDBACK_STATUSES, "Status: all")}</select>
+    <select data-filter-key="kind">${optionList(["point", "area"], "Kind: all")}</select>
+    <select data-filter-key="reviewer">${optionList(reviewers, "Reviewer: all")}</select>
+    <select data-filter-key="source">${optionList(sources, "Source: all")}</select>
+    <select data-filter-key="slack">${optionList(slackStatuses, "Slack: all")}</select>
+    <span class="filter-count" data-filter-count></span>
+  </section>`;
+}
+
+function renderTriageScript() {
+  return `<script>
+(() => {
+  const cards = Array.from(document.querySelectorAll("[data-card]"));
+
+  const panel = document.querySelector("[data-filter-panel]");
+  if (panel) {
+    const textInput = panel.querySelector("[data-filter-text]");
+    const selects = Array.from(panel.querySelectorAll("[data-filter-key]"));
+    const count = panel.querySelector("[data-filter-count]");
+    const emptyNote = document.querySelector("[data-filter-empty]");
+
+    const applyFilters = () => {
+      const text = textInput.value.trim().toLowerCase();
+      let visible = 0;
+      cards.forEach((card) => {
+        const matchesText = !text || card.dataset.search.includes(text);
+        const matchesSelects = selects.every((select) => !select.value || card.dataset[select.dataset.filterKey] === select.value);
+        const show = matchesText && matchesSelects;
+        card.hidden = !show;
+        if (show) visible += 1;
+      });
+      count.textContent = visible === cards.length ? cards.length + " 件" : visible + " / " + cards.length + " 件";
+      if (emptyNote) emptyNote.hidden = visible > 0;
+    };
+
+    textInput.addEventListener("input", applyFilters);
+    selects.forEach((select) => select.addEventListener("change", applyFilters));
+    applyFilters();
+  }
+
+  document.querySelectorAll("[data-status-select]").forEach((select) => {
+    select.addEventListener("change", async () => {
+      const card = select.closest("[data-card]");
+      const previous = card.dataset.status;
+      select.disabled = true;
+      try {
+        const response = await fetch("/feedback/" + encodeURIComponent(select.dataset.feedbackId) + "/status", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: select.value })
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.error || "Status update failed");
+        card.dataset.status = select.value;
+      } catch (error) {
+        select.value = previous;
+        window.alert(error.message);
+      } finally {
+        select.disabled = false;
+      }
+    });
+  });
+})();
+</script>`;
 }
 
 function renderImportScript() {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -102,6 +102,38 @@ test("POST /import rejects unsupported bundle versions", async (t) => {
   assert.deepEqual(await readStoredFeedback(receiver.storePath), []);
 });
 
+test("POST /feedback/:id/status updates triage status and persists it", async (t) => {
+  const receiver = await startReceiver(t);
+  const payload = feedbackPayload("pl_status_1");
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+
+  const response = await postJson(`${receiver.baseUrl}/feedback/${payload.id}/status`, { status: "accepted" });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, { ok: true, id: payload.id, status: "accepted" });
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  assert.equal(stored[0].status, "accepted");
+  assert.match(stored[0].statusUpdatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("POST /feedback/:id/status rejects unknown statuses and ids", async (t) => {
+  const receiver = await startReceiver(t);
+  const payload = feedbackPayload("pl_status_2");
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+
+  const invalid = await postJson(`${receiver.baseUrl}/feedback/${payload.id}/status`, { status: "wontfix" });
+  assert.equal(invalid.status, 400);
+  assert.match(invalid.body.error, /status must be one of/);
+
+  const missing = await postJson(`${receiver.baseUrl}/feedback/pl_missing/status`, { status: "fixed" });
+  assert.equal(missing.status, 404);
+  assert.match(missing.body.error, /Unknown feedback id/);
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  assert.equal(stored[0].status, undefined);
+});
+
 async function startReceiver(t) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();


### PR DESCRIPTION
## 概要

Closes #30

receiver inbox に検索・絞り込み UI と、feedback ごとの軽量 triage status を追加します。`server/feedback.json` を正本としたまま、DB は追加していません。

## 変更内容

### Status 管理
- feedback ごとに `status`（`new` / `accepted` / `fixed` / `ignored`）を追加。未設定の既存データは `new` として表示（マイグレーション不要）
- `POST /feedback/:id/status` endpoint を追加。許可外の status は 400、未知の id は 404
- 更新時に `statusUpdatedAt` を付与して `feedback.json` に永続化
- 各 card のヘッダーに status select、status に応じた色付き左ボーダー（ignored は減光）

### 検索・絞り込み
- フィルタバー: テキスト検索（コメント / reviewer / selector / URL / title / id）+ status / kind / reviewer / source / Slack の select
- reviewer / source / Slack の選択肢は受信データから動的生成
- 表示件数（`X / N 件`）と 0 件時のメッセージ
- クライアントサイドフィルタ（ページ再取得なし）

### その他
- テスト 2 件追加（status 更新の永続化 / 不正 status・未知 id の拒否）→ 計 6 件
- README 日英に inbox controls を追記

## 動作確認（headless Chrome + CDP）

- receiver 経由 2 件（point/area、別 reviewer）+ import 1 件を投入
- reviewer / source / kind / status の各フィルタとテキスト検索が正しく絞り込み、件数表示と 0 件メッセージも動作
- card の select で status 変更 → `feedback.json` に即永続化、reload 後も保持
- **import された feedback と receiver 経由の feedback の両方で triage が動作**（受け入れ条件）
- `npm run check`（lint + テスト 6 件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)