### PR TITLE
Receiver inbox から GitHub Issue を作成する

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -165,6 +165,7 @@ node server/receive.js
 - The inbox has text search plus status / kind / reviewer / source / Slack filters
 - Each feedback has a triage status (`new` / `accepted` / `fixed` / `ignored`) editable from the card; statuses persist to `server/feedback.json`
 - `POST /feedback/:id/status` updates the status via the API (body: `{"status": "accepted"}`)
+- With GitHub configured, each inbox card can create a GitHub Issue (see below)
 - Imports `.patchloop-feedback.json` files from the inbox UI
 - Returns the raw JSON at `GET /feedback.json`
 - Serves saved screenshots from `GET /screenshots/:file`
@@ -218,6 +219,25 @@ SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
 If Slack forwarding fails, the receiver still stores the payload. The Slack result is visible in the saved payload under `integrations.slack` and in the inbox `Slack` row. Screenshot `dataUrl` values are saved as files by the receiver and replaced with `screenshot.url` in stored payloads.
+
+### Creating GitHub Issues
+
+Feedback in the inbox can be turned into GitHub Issues. Issue creation happens on the receiver; the token never reaches the browser.
+
+```sh
+GITHUB_TOKEN="github_pat_..." GITHUB_REPO="owner/repo" node server/receive.js
+```
+
+- `GITHUB_TOKEN` / `githubToken` — GitHub token. **A fine-grained PAT scoped to the target repository with Issues: write is recommended**
+- `GITHUB_REPO` / `githubRepo` — repository to create issues in (`owner/repo`)
+- `GITHUB_LABELS` / `githubLabels` — labels to apply (comma-separated in env, array in config)
+- `GITHUB_ASSIGNEES` / `githubAssignees` — assignees (same formats)
+- `GITHUB_API_BASE` / `githubApiBase` — API base URL (defaults to `https://api.github.com`; override for GHES or tests)
+- `GITHUB_TIMEOUT_MS` / `githubTimeoutMs` — timeout (defaults to `8000`)
+
+When configured, each inbox card shows a `Create GitHub Issue` button. Created issues include the comment, reviewer, page URL, selector, target position, viewport, screenshot link, and the raw payload. The result is persisted as `integrations.github` and the card shows the issue link (or the error on failure). Creating a second issue from the same feedback is rejected. The API equivalent is `POST /feedback/:id/github-issue`.
+
+The screenshot image only renders inside the issue if GitHub can reach your `publicBaseUrl`; with a local receiver the link still works locally.
 
 ## Slack Direct Mode
 
@@ -274,12 +294,11 @@ The receiver validates the bundle version and payload shape, saves the screensho
 
 ## Current Boundary
 
-This version does not send to GitHub directly yet. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The widget feedback list can be persisted in browser `localStorage`, but there is still no shared long-term database. Use a receiver `endpoint` or download mode when you need to collect feedback outside the current browser.
+GitHub Issue creation is a manual action from the receiver inbox only; there is no automatic creation or two-way sync. Slack support is currently a local-receiver Incoming Webhook prototype. Received feedback is stored by the local receiver. The widget feedback list can be persisted in browser `localStorage`, but there is still no shared long-term database. Use a receiver `endpoint` or download mode when you need to collect feedback outside the current browser.
 
 Not included yet:
 
 - Slack App / OAuth integration
-- GitHub Issue creation
 - Persistent database
 - Pixel-perfect browser screenshot capture
 - Auth

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ node server/receive.js
 - inbox にはテキスト検索と status / kind / reviewer / source / Slack の絞り込みがあります
 - 各 feedback には triage status（`new` / `accepted` / `fixed` / `ignored`）があり、card 上の select から変更できます。status は `server/feedback.json` に永続化されます
 - `POST /feedback/:id/status` で API からも status を更新できます（body は `{"status": "accepted"}` 形式）
+- GitHub 連携を設定すると、inbox の各 card から GitHub Issue を作成できます（後述）
 - inbox UI から `.patchloop-feedback.json` を選択して import できます
 - `GET /feedback.json` で raw JSON を返します
 - `GET /screenshots/:file` で保存済み screenshot を返します
@@ -218,6 +219,25 @@ SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." node server/receive.js
 ```
 
 Slack 転送に失敗しても、receiver は payload を保存します。Slack の結果は保存済み payload の `integrations.slack` と inbox の `Slack` 行で確認できます。screenshot の `dataUrl` は receiver でファイル保存されたあと payload から取り除かれ、`screenshot.url` として参照されます。
+
+### GitHub Issue 作成
+
+inbox の feedback から GitHub Issue を作成できます。Issue 作成は receiver 側で行い、token がブラウザに渡ることはありません。
+
+```sh
+GITHUB_TOKEN="github_pat_..." GITHUB_REPO="owner/repo" node server/receive.js
+```
+
+- `GITHUB_TOKEN` / `githubToken` — GitHub token。**fine-grained PAT で対象リポジトリ + Issues: write のみに絞ることを推奨**
+- `GITHUB_REPO` / `githubRepo` — Issue を作成するリポジトリ（`owner/repo` 形式）
+- `GITHUB_LABELS` / `githubLabels` — 付与するラベル（env はカンマ区切り、config は配列）
+- `GITHUB_ASSIGNEES` / `githubAssignees` — アサイン先（同上）
+- `GITHUB_API_BASE` / `githubApiBase` — API base URL（デフォルト `https://api.github.com`。GHES やテスト時に変更）
+- `GITHUB_TIMEOUT_MS` / `githubTimeoutMs` — timeout（デフォルト `8000`）
+
+設定済みの場合、inbox の各 card に `Create GitHub Issue` ボタンが表示されます。作成された issue には feedback 本文・reviewer・ページ URL・selector・対象位置・viewport・screenshot link・raw payload が含まれます。結果は保存済み payload の `integrations.github` に永続化され、card には issue link（失敗時はエラー）が表示されます。同じ feedback からの二重作成は拒否されます。API から行う場合は `POST /feedback/:id/github-issue` を使います。
+
+screenshot の画像は GitHub から `publicBaseUrl` に到達できる場合のみ issue 上に表示されます（ローカル receiver のままなら link のみ機能します）。
 
 ## Slack direct mode
 
@@ -274,12 +294,11 @@ receiver は bundle version と payload shape を検証し、screenshot の `dat
 
 ## 現在の境界
 
-このバージョンは、まだ GitHub には直接送信しません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の feedback list はブラウザの `localStorage` に保存できますが、チーム共有や長期保存用の永続 DB はまだありません。feedback を回収したい場合は `endpoint` 経由で receiver に送るか、download mode で bundle を保存してください。
+GitHub Issue 作成は receiver inbox からの手動操作のみで、自動作成や issue との双方向同期はありません。Slack は local receiver 経由の Incoming Webhook prototype として扱います。受信したフィードバックはローカル receiver に保存されます。widget 内の feedback list はブラウザの `localStorage` に保存できますが、チーム共有や長期保存用の永続 DB はまだありません。feedback を回収したい場合は `endpoint` 経由で receiver に送るか、download mode で bundle を保存してください。
 
 未対応:
 
 - Slack App / OAuth 連携
-- GitHub Issue 作成
 - 永続 DB
 - pixel-perfect なブラウザ screenshot capture
 - 認証

--- a/server/receive.js
+++ b/server/receive.js
@@ -21,6 +21,13 @@ const SLACK_TIMEOUT_MS = Number(process.env.SLACK_TIMEOUT_MS || config.slackTime
 const SLACK_IMAGE_MODE = normalizeSlackImageMode(process.env.SLACK_IMAGE_MODE || config.slackImageMode || "auto");
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN || config.slackBotToken || "";
 const SLACK_UPLOAD_CHANNEL_ID = process.env.SLACK_UPLOAD_CHANNEL_ID || config.slackUploadChannelId || "";
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || config.githubToken || "";
+const GITHUB_REPO = normalizeGitHubRepo(process.env.GITHUB_REPO || config.githubRepo || "");
+const GITHUB_LABELS = normalizeStringList(process.env.GITHUB_LABELS ?? config.githubLabels);
+const GITHUB_ASSIGNEES = normalizeStringList(process.env.GITHUB_ASSIGNEES ?? config.githubAssignees);
+const GITHUB_API_BASE = trimTrailingSlash(process.env.GITHUB_API_BASE || config.githubApiBase || "https://api.github.com");
+const GITHUB_TIMEOUT_MS = Number(process.env.GITHUB_TIMEOUT_MS || config.githubTimeoutMs || 8000);
+const GITHUB_CONFIGURED = Boolean(GITHUB_TOKEN && GITHUB_REPO);
 const IMPORT_BUNDLE_KIND = "patchloop-feedback-bundle";
 const IMPORT_BUNDLE_VERSION = 1;
 const FEEDBACK_STATUSES = ["new", "accepted", "fixed", "ignored"];
@@ -52,6 +59,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  const githubMatch = req.method === "POST" && /^\/feedback\/([^/]+)\/github-issue$/.exec(req.url);
+  if (githubMatch) {
+    handlePostGitHubIssue(req, res, decodeURIComponent(githubMatch[1]));
+    return;
+  }
+
   if (req.method === "GET" && (req.url === "/" || req.url === "/index.html")) {
     handleGetInbox(req, res);
     return;
@@ -79,6 +92,7 @@ server.listen(PORT, HOST, () => {
   console.log(`[PatchLoop receiver] Slack webhook: ${SLACK_WEBHOOK_URL ? "enabled" : "disabled"}`);
   console.log(`[PatchLoop receiver] Slack image mode: ${SLACK_IMAGE_MODE}`);
   console.log(`[PatchLoop receiver] Slack file upload: ${SLACK_BOT_TOKEN && SLACK_UPLOAD_CHANNEL_ID ? "enabled" : "disabled"}`);
+  console.log(`[PatchLoop receiver] GitHub issues: ${GITHUB_CONFIGURED ? `enabled (${GITHUB_REPO})` : "disabled"}`);
 });
 
 function setCors(res) {
@@ -115,6 +129,16 @@ function normalizeSlackImageMode(value) {
   const mode = String(value || "").trim().toLowerCase();
   if (["auto", "link", "block", "upload", "off"].includes(mode)) return mode;
   return "auto";
+}
+
+function normalizeGitHubRepo(value) {
+  const repo = String(value || "").trim();
+  return /^[\w.-]+\/[\w.-]+$/.test(repo) ? repo : "";
+}
+
+function normalizeStringList(value) {
+  const items = Array.isArray(value) ? value : String(value || "").split(",");
+  return items.map((item) => String(item).trim()).filter(Boolean);
 }
 
 function handlePostFeedback(req, res) {
@@ -205,6 +229,140 @@ function handlePostStatus(req, res, id) {
   });
 }
 
+function handlePostGitHubIssue(req, res, id) {
+  readJsonBody(req, res, async () => {
+    if (!GITHUB_CONFIGURED) {
+      respondJson(res, 400, { ok: false, error: "GitHub integration is not configured. Set GITHUB_TOKEN and GITHUB_REPO." });
+      return;
+    }
+
+    const item = feedback.find((entry) => entry.id === id);
+    if (!item) {
+      respondJson(res, 404, { ok: false, error: `Unknown feedback id: ${id}` });
+      return;
+    }
+
+    const existing = item.integrations && item.integrations.github;
+    if (existing && existing.status === "created") {
+      respondJson(res, 409, { ok: false, error: `GitHub issue already created: ${existing.url || `#${existing.issueNumber}`}`, github: existing });
+      return;
+    }
+
+    const github = await createGitHubIssue(item);
+    item.integrations = { ...(item.integrations || {}), github };
+    persist();
+    console.log(`[PatchLoop receiver] github issue ${github.status} id=${id}${github.url ? ` url=${github.url}` : ""}`);
+
+    if (github.status === "created") {
+      respondJson(res, 201, { ok: true, github });
+    } else {
+      respondJson(res, 502, { ok: false, error: github.error || "GitHub issue creation failed", github });
+    }
+  });
+}
+
+async function createGitHubIssue(item) {
+  const issue = {
+    title: gitHubIssueTitle(item),
+    body: gitHubIssueBody(item)
+  };
+  if (GITHUB_LABELS.length) issue.labels = GITHUB_LABELS;
+  if (GITHUB_ASSIGNEES.length) issue.assignees = GITHUB_ASSIGNEES;
+
+  try {
+    const response = await postJson(`${GITHUB_API_BASE}/repos/${GITHUB_REPO}/issues`, issue, {
+      "Authorization": `Bearer ${GITHUB_TOKEN}`,
+      "Accept": "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28"
+    }, GITHUB_TIMEOUT_MS);
+
+    if (response.statusCode === 201) {
+      let parsed = {};
+      try {
+        parsed = JSON.parse(response.body);
+      } catch (_) {
+        // Issue was created; metadata stays partial if the body is unreadable.
+      }
+      return {
+        status: "created",
+        issueNumber: parsed.number ?? null,
+        url: parsed.html_url || "",
+        createdAt: new Date().toISOString()
+      };
+    }
+
+    return {
+      status: "failed",
+      statusCode: response.statusCode,
+      error: truncate(gitHubErrorMessage(response.body) || "GitHub API returned a non-201 response", 240),
+      failedAt: new Date().toISOString()
+    };
+  } catch (error) {
+    return { status: "failed", error: error.message, failedAt: new Date().toISOString() };
+  }
+}
+
+function gitHubErrorMessage(raw) {
+  try {
+    return JSON.parse(raw).message || "";
+  } catch (_) {
+    return String(raw || "");
+  }
+}
+
+function gitHubIssueTitle(item) {
+  const firstLine = String(item.comment || "").split("\n")[0].trim() || "(no comment)";
+  return `[PatchLoop] ${truncate(firstLine, 80)}`;
+}
+
+function gitHubIssueBody(item) {
+  const target = item.target || {};
+  const env = item.environment || {};
+  const page = item.page || {};
+  const lines = [];
+
+  lines.push("## Feedback", "");
+  lines.push(...String(item.comment || "(empty comment)").split("\n").map((line) => `> ${line}`), "");
+  lines.push("| | |");
+  lines.push("|---|---|");
+  lines.push(`| Reviewer | ${mdTableCell(item.reviewer || "(no name)")} |`);
+  lines.push(`| Page | ${page.url ? `[${mdTableCell(page.title || page.url)}](${page.url})` : mdTableCell(page.title || "(unknown)")} |`);
+  lines.push(`| Target | ${mdTableCell(formatTarget(target))} |`);
+  lines.push(`| Selector | \`${String(target.selector || "(none)").replaceAll("\`", "'")}\` |`);
+  lines.push(`| Viewport | ${mdTableCell(formatViewport(env.viewport))} |`);
+  lines.push(`| Created | ${mdTableCell(item.createdAt || item.receivedAt || "(unknown)")} |`);
+  lines.push(`| Feedback ID | \`${String(item.id || "-").replaceAll("\`", "'")}\` |`);
+  lines.push("");
+
+  if (target.text) {
+    lines.push("### Element text", "");
+    lines.push(...truncate(String(target.text), 500).split("\n").map((line) => `> ${line}`), "");
+  }
+
+  const screenshotUrl = screenshotUrlFor(item.screenshot);
+  if (screenshotUrl) {
+    lines.push("### Screenshot", "");
+    lines.push(`![PatchLoop screenshot](${screenshotUrl})`, "");
+    lines.push(`[Open screenshot](${screenshotUrl})`, "");
+    lines.push("_The image only renders if the receiver's `publicBaseUrl` is reachable from GitHub._", "");
+  } else if (item.screenshot && item.screenshot.status) {
+    lines.push(`Screenshot: ${formatScreenshotStatus(item.screenshot)}`, "");
+  }
+
+  lines.push("<details><summary>Raw payload</summary>", "");
+  lines.push("```json");
+  lines.push(JSON.stringify(item, null, 2));
+  lines.push("```");
+  lines.push("", "</details>", "");
+  lines.push("---");
+  lines.push("_Created from the PatchLoop receiver inbox._");
+  return lines.join("\n");
+}
+
+function mdTableCell(value) {
+  return String(value ?? "").replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
 function readJsonBody(req, res, onJson) {
   let received = 0;
   const chunks = [];
@@ -226,7 +384,8 @@ function readJsonBody(req, res, onJson) {
     if (aborted) return;
     let payload;
     try {
-      payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      const raw = Buffer.concat(chunks).toString("utf8");
+      payload = raw.trim() ? JSON.parse(raw) : {};
     } catch (_) {
       respondJson(res, 400, { ok: false, error: "Invalid JSON" });
       return;
@@ -498,30 +657,31 @@ async function deliverToSlack(item) {
   }
 }
 
-function postJson(targetUrl, body) {
+function postJson(targetUrl, body, extraHeaders = {}, timeoutMs = SLACK_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     let url;
     try {
       url = new URL(targetUrl);
     } catch (error) {
-      reject(new Error(`Invalid SLACK_WEBHOOK_URL: ${error.message}`));
+      reject(new Error(`Invalid request URL: ${error.message}`));
       return;
     }
 
     const client = url.protocol === "https:" ? https : url.protocol === "http:" ? http : null;
     if (!client) {
-      reject(new Error(`Unsupported webhook protocol: ${url.protocol}`));
+      reject(new Error(`Unsupported request protocol: ${url.protocol}`));
       return;
     }
 
     const json = JSON.stringify(body);
     const request = client.request(url, {
       method: "POST",
-      timeout: SLACK_TIMEOUT_MS,
+      timeout: timeoutMs,
       headers: {
         "Content-Type": "application/json",
         "Content-Length": Buffer.byteLength(json),
-        "User-Agent": "PatchLoop receiver"
+        "User-Agent": "PatchLoop receiver",
+        ...extraHeaders
       }
     }, (response) => {
       let raw = "";
@@ -535,7 +695,7 @@ function postJson(targetUrl, body) {
     });
 
     request.on("timeout", () => {
-      request.destroy(new Error(`Slack webhook timed out after ${SLACK_TIMEOUT_MS}ms`));
+      request.destroy(new Error(`Request to ${url.hostname} timed out after ${timeoutMs}ms`));
     });
     request.on("error", reject);
     request.write(json);
@@ -888,6 +1048,8 @@ function renderInbox(items) {
     const importedAt = escapeHtml(item.importedAt || "");
     const status = feedbackStatusOf(item);
     const slackStatus = escapeHtml((slack && slack.status) || "unknown");
+    const github = item.integrations && item.integrations.github;
+    const githubStatus = escapeHtml((github && github.status) || "none");
     const searchText = escapeHtml([item.comment, item.reviewer, target.selector, page.url, page.title, item.id]
       .filter(Boolean).join(" ").toLowerCase());
     const statusOptions = FEEDBACK_STATUSES
@@ -897,7 +1059,7 @@ function renderInbox(items) {
       ? `${env.viewport.width}×${env.viewport.height}`
       : "";
     return `
-      <article class="card" data-card data-status="${status}" data-kind="${kind}" data-reviewer="${reviewer}" data-source="${source}" data-slack="${slackStatus}" data-search="${searchText}">
+      <article class="card" data-card data-status="${status}" data-kind="${kind}" data-reviewer="${reviewer}" data-source="${source}" data-slack="${slackStatus}" data-github="${githubStatus}" data-search="${searchText}">
         <header>
           <span class="kind kind-${kind}">${kind}</span>
           <span class="reviewer">${reviewer || "(no name)"}</span>
@@ -915,6 +1077,7 @@ function renderInbox(items) {
           <div><dt>Viewport</dt><dd>${escapeHtml(viewport)}</dd></div>
           <div><dt>Source</dt><dd>${source}</dd></div>
           <div><dt>Slack</dt><dd>${escapeHtml(formatSlackStatus(slack))}</dd></div>
+          <div><dt>GitHub</dt><dd>${renderGitHubCell(github, item.id)}</dd></div>
           <div><dt>Created</dt><dd>${createdAt}</dd></div>
           ${importedAt ? `<div><dt>Imported</dt><dd>${importedAt}</dd></div>` : ""}
         </dl>
@@ -958,6 +1121,9 @@ function renderInbox(items) {
     .card[data-status="ignored"] { border-left-color: #c2c9c5; opacity: 0.72; }
     .card header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 12px; color: #65716d; }
     .status-control select { min-height: 26px; border: 1px solid #d9e1dd; border-radius: 999px; background: #f7f8f5; padding: 2px 8px; font: inherit; font-size: 11px; font-weight: 800; color: #14211d; cursor: pointer; }
+    .github-create { min-height: 24px; border: 1px solid #0f7b63; border-radius: 6px; background: #fff; color: #0f7b63; padding: 1px 8px; font: inherit; font-size: 11px; font-weight: 800; cursor: pointer; }
+    .github-create:disabled { opacity: 0.6; cursor: default; }
+    .github-error { color: #b83d4d; }
     .kind { padding: 2px 8px; border-radius: 999px; font-weight: 800; color: #fff; font-size: 11px; text-transform: uppercase; }
     .kind-point { background: #0f7b63; }
     .kind-area { background: #d1495b; }
@@ -1016,6 +1182,7 @@ function renderFilterPanel(items) {
   const reviewers = unique((item) => item.reviewer || "");
   const sources = unique((item) => item.source || "receiver");
   const slackStatuses = unique((item) => (item.integrations && item.integrations.slack && item.integrations.slack.status) || "unknown");
+  const githubStatuses = unique((item) => (item.integrations && item.integrations.github && item.integrations.github.status) || "none");
 
   return `
   <section class="filter-panel" data-filter-panel>
@@ -1025,8 +1192,27 @@ function renderFilterPanel(items) {
     <select data-filter-key="reviewer">${optionList(reviewers, "Reviewer: all")}</select>
     <select data-filter-key="source">${optionList(sources, "Source: all")}</select>
     <select data-filter-key="slack">${optionList(slackStatuses, "Slack: all")}</select>
+    <select data-filter-key="github">${optionList(githubStatuses, "GitHub: all")}</select>
     <span class="filter-count" data-filter-count></span>
   </section>`;
+}
+
+function renderGitHubCell(github, id) {
+  if (github && github.status === "created") {
+    const number = github.issueNumber != null ? `#${escapeHtml(String(github.issueNumber))}` : "issue";
+    return github.url
+      ? `<a href="${escapeHtml(github.url)}" target="_blank" rel="noopener">${number} created</a>`
+      : `${number} created`;
+  }
+
+  if (!GITHUB_CONFIGURED) return "not configured";
+
+  const button = `<button type="button" class="github-create" data-github-create data-feedback-id="${escapeHtml(id || "")}">Create GitHub Issue</button>`;
+  if (github && github.status === "failed") {
+    const code = github.statusCode ? ` (${escapeHtml(String(github.statusCode))})` : "";
+    return `<span class="github-error">failed${code}: ${escapeHtml(github.error || "unknown error")}</span> ${button}`;
+  }
+  return button;
 }
 
 function renderTriageScript() {
@@ -1059,6 +1245,21 @@ function renderTriageScript() {
     selects.forEach((select) => select.addEventListener("change", applyFilters));
     applyFilters();
   }
+
+  document.querySelectorAll("[data-github-create]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      button.disabled = true;
+      button.textContent = "Creating...";
+      try {
+        const response = await fetch("/feedback/" + encodeURIComponent(button.dataset.feedbackId) + "/github-issue", { method: "POST" });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.error || "GitHub issue creation failed");
+      } catch (error) {
+        window.alert(error.message);
+      }
+      window.location.reload();
+    });
+  });
 
   document.querySelectorAll("[data-status-select]").forEach((select) => {
     select.addEventListener("change", async () => {

--- a/server/receiver.config.example.json
+++ b/server/receiver.config.example.json
@@ -10,5 +10,11 @@
   "slackImageMode": "auto",
   "slackBotToken": "",
   "slackUploadChannelId": "",
-  "slackTimeoutMs": 5000
+  "slackTimeoutMs": 5000,
+  "githubToken": "",
+  "githubRepo": "",
+  "githubLabels": [],
+  "githubAssignees": [],
+  "githubApiBase": "https://api.github.com",
+  "githubTimeoutMs": 8000
 }

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const { spawn } = require("node:child_process");
 const fs = require("node:fs/promises");
+const http = require("node:http");
 const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
@@ -117,6 +118,105 @@ test("POST /feedback/:id/status updates triage status and persists it", async (t
   assert.match(stored[0].statusUpdatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
+test("POST /feedback/:id/github-issue creates an issue via the GitHub API", async (t) => {
+  const github = await startMockGitHub(t, (res) => {
+    res.writeHead(201, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ number: 7, html_url: "https://github.com/acme/demo/issues/7" }));
+  });
+  const receiver = await startReceiver(t, {
+    GITHUB_TOKEN: "test-token",
+    GITHUB_REPO: "acme/demo",
+    GITHUB_LABELS: "feedback, patchloop",
+    GITHUB_ASSIGNEES: "kosako",
+    GITHUB_API_BASE: github.baseUrl
+  });
+  const payload = feedbackPayload("pl_github_1");
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+
+  const response = await postJson(`${receiver.baseUrl}/feedback/${payload.id}/github-issue`, {});
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.ok, true);
+  assert.equal(response.body.github.issueNumber, 7);
+  assert.equal(response.body.github.url, "https://github.com/acme/demo/issues/7");
+
+  const request = github.requests[0];
+  assert.equal(request.url, "/repos/acme/demo/issues");
+  assert.equal(request.headers.authorization, "Bearer test-token");
+  assert.match(request.body.title, /^\[PatchLoop\] Move this button above the fold\./);
+  assert.match(request.body.body, /## Feedback/);
+  assert.match(request.body.body, /Test Reviewer/);
+  assert.match(request.body.body, /#hero button/);
+  assert.match(request.body.body, /screenshots\//);
+  assert.deepEqual(request.body.labels, ["feedback", "patchloop"]);
+  assert.deepEqual(request.body.assignees, ["kosako"]);
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  assert.equal(stored[0].integrations.github.status, "created");
+  assert.equal(stored[0].integrations.github.issueNumber, 7);
+
+  const again = await postJson(`${receiver.baseUrl}/feedback/${payload.id}/github-issue`, {});
+  assert.equal(again.status, 409);
+  assert.equal(github.requests.length, 1);
+});
+
+test("POST /feedback/:id/github-issue persists failures and requires configuration", async (t) => {
+  const unconfigured = await startReceiver(t);
+  const payload = feedbackPayload("pl_github_2");
+  await postJson(`${unconfigured.baseUrl}/feedback`, payload);
+
+  const rejected = await postJson(`${unconfigured.baseUrl}/feedback/${payload.id}/github-issue`, {});
+  assert.equal(rejected.status, 400);
+  assert.match(rejected.body.error, /not configured/);
+
+  const github = await startMockGitHub(t, (res) => {
+    res.writeHead(422, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ message: "Validation Failed" }));
+  });
+  const receiver = await startReceiver(t, {
+    GITHUB_TOKEN: "test-token",
+    GITHUB_REPO: "acme/demo",
+    GITHUB_API_BASE: github.baseUrl
+  });
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+
+  const failed = await postJson(`${receiver.baseUrl}/feedback/${payload.id}/github-issue`, {});
+  assert.equal(failed.status, 502);
+  assert.match(failed.body.error, /Validation Failed/);
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  assert.equal(stored[0].integrations.github.status, "failed");
+  assert.equal(stored[0].integrations.github.statusCode, 422);
+});
+
+function startMockGitHub(t, respond) {
+  return new Promise((resolve) => {
+    const requests = [];
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        requests.push({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: raw ? JSON.parse(raw) : null
+        });
+        respond(res, requests[requests.length - 1]);
+      });
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      t.after(() => new Promise((done) => server.close(done)));
+      resolve({ baseUrl: `http://127.0.0.1:${port}`, requests });
+    });
+  });
+}
+
 test("POST /feedback/:id/status rejects unknown statuses and ids", async (t) => {
   const receiver = await startReceiver(t);
   const payload = feedbackPayload("pl_status_2");
@@ -134,7 +234,7 @@ test("POST /feedback/:id/status rejects unknown statuses and ids", async (t) => 
   assert.equal(stored[0].status, undefined);
 });
 
-async function startReceiver(t) {
+async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();
   const baseUrl = `http://127.0.0.1:${port}`;
@@ -153,7 +253,10 @@ async function startReceiver(t) {
       SLACK_IMAGE_MODE: "off",
       SLACK_BOT_TOKEN: "",
       SLACK_UPLOAD_CHANNEL_ID: "",
-      PATCHLOOP_RECEIVER_CONFIG: path.join(tempDir, "missing-config.json")
+      GITHUB_TOKEN: "",
+      GITHUB_REPO: "",
+      PATCHLOOP_RECEIVER_CONFIG: path.join(tempDir, "missing-config.json"),
+      ...extraEnv
     },
     stdio: ["ignore", "pipe", "pipe"]
   });


### PR DESCRIPTION
## 概要

Closes #29

receiver inbox の feedback から GitHub Issue を作成できるようにします。事前確認の通り **token 方式**（receiver 側に閉じる、ブラウザには渡さない）で、EC2 等へのデプロイ時は環境変数で注入する運用にそのまま乗ります。

## 変更内容

### Receiver
- `POST /feedback/:id/github-issue` を追加。GitHub REST API（`POST /repos/{owner}/{repo}/issues`）で issue を作成
- issue body には feedback 本文 / reviewer / ページ link / target 位置 / selector / viewport / screenshot link / raw payload（details 折りたたみ）を含む
- 結果は `integrations.github` として `feedback.json` に永続化（成功: `created` + issue 番号 + URL、失敗: `failed` + statusCode + エラー）
- 二重作成は 409 で拒否。未設定時は 400
- 設定は Slack と同じパターン（env > config）: `GITHUB_TOKEN` / `GITHUB_REPO`（owner/repo 形式を検証）/ `GITHUB_LABELS` / `GITHUB_ASSIGNEES` / `GITHUB_API_BASE`（GHES・テスト用）/ `GITHUB_TIMEOUT_MS`
- README で **fine-grained PAT（対象リポジトリ + Issues: write のみ）を推奨**と明記

### Inbox UI
- 各 card に GitHub 行を追加: 設定済みなら `Create GitHub Issue` ボタン、作成済みなら issue link（#番号）、失敗時はエラー + リトライボタン、未設定なら `not configured`
- フィルタバーに GitHub status の select を追加

### その他
- テスト 2 件追加（mock GitHub API に対して: 作成成功 + リクエスト内容検証 + 409 / 未設定 400 + 失敗の永続化）→ 計 8 件
- `receiver.config.example.json` / README 日英を更新、「現在の境界」の GitHub 記述も最新化

## 動作確認

- `npm run check`（lint + テスト 8 件）パス
- headless Chrome + mock GitHub API: inbox の `Create GitHub Issue` ボタン → issue 作成 → card に `#101 created` リンク表示 → `integrations.github` 永続化 → GitHub フィルタで絞り込み、まで実 UI で確認

## ローカルで実 GitHub に対して試す場合

```sh
GITHUB_TOKEN="github_pat_..." GITHUB_REPO="kosako/PatchLoop" node server/receive.js
```

※実リポジトリに issue が作られるので、検証用リポジトリの利用をおすすめします。

## 関連 issue（スコープ外・起票済み）

- #43 公開デプロイ時の receiver ハードニング（認証・CORS）
- #44 widget→receiver の ingest ペア認証と受信データ安全性（SVG stored XSS 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)