### PR TITLE
Screenshot の body 直列化を XHTML にする

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,8 @@ const browserGlobals = {
   navigator: "readonly",
   Node: "readonly",
   requestAnimationFrame: "readonly",
-  window: "readonly"
+  window: "readonly",
+  XMLSerializer: "readonly"
 };
 
 const nodeGlobals = {

--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -525,6 +525,7 @@
     const font = bodyStyle.font || bodyStyle.fontFamily || "system-ui, sans-serif";
     const styles = `${freezeViewportUnits(collectReadableStyles(), width, height)}\n* { box-sizing: border-box; }\n`;
     const overlayMarkup = renderScreenshotOverlay(overlay);
+    const bodyMarkup = serializeAsXhtml(bodyClone);
 
     return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
@@ -535,13 +536,31 @@
         <style><![CDATA[${styles.replaceAll("]]>", "]]]]><![CDATA[>")}]]></style>
       </head>
       <body style="margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
-        ${bodyClone.innerHTML}
+        ${bodyMarkup}
       </body>
     </html>
   </foreignObject>
   <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" fill="none" stroke="#d9e1dd"/>
   ${overlayMarkup}
 </svg>`;
+  }
+
+  // The SVG is parsed as XML, so the clone must be serialized as XHTML:
+  // innerHTML emits HTML syntax (unclosed void elements like <br>, named
+  // entities like &nbsp;) that breaks XML parsing and renders the whole
+  // snapshot as a broken image. XMLSerializer self-closes void elements and
+  // emits characters instead of HTML-only entities.
+  function serializeAsXhtml(root) {
+    const serializer = new XMLSerializer();
+    return Array.from(root.childNodes)
+      .map((node) => {
+        try {
+          return serializer.serializeToString(node);
+        } catch (_) {
+          return "";
+        }
+      })
+      .join("");
   }
 
   // Media queries inside the snapshot re-evaluate against the SVG's rendered


### PR DESCRIPTION
## 概要

Closes #46

screenshot SVG は XML として解析されるのに、body clone を `innerHTML`（HTML 構文）で埋めていたため、`<br>` `<img>` `<input>` 等の void 要素や `&nbsp;` を 1 つでも含むページ（≒ほぼすべての実ページ）で snapshot が描画不能になっていた問題の修正です。

## 変更内容

- `buildScreenshotSvg` の body 埋め込みを `XMLSerializer` による XHTML 直列化に変更（void 要素は自己終了、HTML 専用エンティティは文字に展開される）
- ESLint の browser globals に `XMLSerializer` を追加

## 動作確認（headless Chrome + CDP）

`<br>` / `<img>` / `<input>` / `<hr>` / `<meta>` / `&nbsp;` / `&copy;` 等を詰め込んだ torture page で capture:

- 修正前の方式（innerHTML）では同等 SVG が image として **BROKEN** になることを事前に実証済み
- 修正後: 保存された SVG が image としてロード成功、`<br />` に自己終了化、`&nbsp;` エンティティ消滅、描画内容も改行・エンティティ・input 値・textarea まで再現（スクショ添付可能）
- `npm run check`（lint + テスト 8 件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)