### PR TITLE
Feedback store をクラッシュセーフにする

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -511,19 +511,43 @@ function handleGetScreenshot(req, res) {
   });
 }
 
+// An unreadable store must never be silently replaced: persist() rewrites the
+// whole file, so starting from [] would destroy all previous feedback on the
+// next write. Move the broken file aside and start fresh instead.
 function loadFeedback() {
+  let raw;
   try {
-    const raw = fs.readFileSync(STORE_PATH, "utf8");
+    raw = fs.readFileSync(STORE_PATH, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.warn(`[PatchLoop receiver] feedback store unreadable: ${error.message}`);
+    }
+    return [];
+  }
+
+  try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (_) {
+    if (!Array.isArray(parsed)) throw new Error("store content is not an array");
+    return parsed;
+  } catch (error) {
+    const backupPath = `${STORE_PATH}.corrupt-${Date.now()}`;
+    try {
+      fs.renameSync(STORE_PATH, backupPath);
+      console.warn(`[PatchLoop receiver] feedback store corrupt (${error.message}); backed up to ${backupPath}`);
+    } catch (backupError) {
+      console.warn(`[PatchLoop receiver] feedback store corrupt and backup failed: ${backupError.message}`);
+    }
     return [];
   }
 }
 
+// Write-then-rename keeps the store readable even if the process dies
+// mid-write; a torn direct write would corrupt the only copy.
 function persist() {
   fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
-  fs.writeFileSync(STORE_PATH, JSON.stringify(feedback, null, 2));
+  const tempPath = `${STORE_PATH}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(feedback, null, 2));
+  fs.renameSync(tempPath, STORE_PATH);
 }
 
 function saveScreenshot(screenshot, id) {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -234,6 +234,29 @@ test("POST /feedback/:id/status rejects unknown statuses and ids", async (t) => 
   assert.equal(stored[0].status, undefined);
 });
 
+test("corrupt feedback store is backed up instead of overwritten", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
+  const storePath = path.join(tempDir, "feedback.json");
+  const corruptContent = '[{"id": "pl_old", "comment": "truncated...';
+  await fs.writeFile(storePath, corruptContent);
+  t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+
+  const receiver = await startReceiver(t, { FEEDBACK_STORE_PATH: storePath });
+  const payload = feedbackPayload("pl_after_corruption");
+  const response = await postJson(`${receiver.baseUrl}/feedback`, payload);
+  assert.equal(response.status, 201);
+
+  const stored = await readStoredFeedback(storePath);
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].id, payload.id);
+
+  const entries = await fs.readdir(tempDir);
+  const backup = entries.find((name) => name.startsWith("feedback.json.corrupt-"));
+  assert.ok(backup, `expected a corrupt backup file, found: ${entries.join(", ")}`);
+  assert.equal(await fs.readFile(path.join(tempDir, backup), "utf8"), corruptContent);
+  assert.ok(!entries.includes("feedback.json.tmp"), "temp file should not linger after persist");
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();


### PR DESCRIPTION
## 概要

Closes #47

`feedback.json` が壊れると黙って空扱い → 次の保存で上書きされ**全データ消失**、という経路の修正です。

## 変更内容

- `persist()`: temp file（`feedback.json.tmp`）に書いてから `renameSync` するアトミック書き込みに変更。書き込み途中のクラッシュでも既存 store は無傷
- `loadFeedback()`: parse できない store は `feedback.json.corrupt-<timestamp>` に退避して起動ログで警告。ENOENT 以外の読み込みエラーも警告を出す
- テスト追加: 壊れた store で起動 → 新規保存後も退避ファイルに元の内容が残り、tmp ファイルが残留しないことを実 HTTP で検証（計 9 件、全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)