### PR TITLE
ユーザー由来 URL のリンク化を http(s) に限定する

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -325,8 +325,9 @@ function gitHubIssueBody(item) {
   lines.push(...String(item.comment || "(empty comment)").split("\n").map((line) => `> ${line}`), "");
   lines.push("| | |");
   lines.push("|---|---|");
+  const pageLink = mdLinkUrl(page.url);
   lines.push(`| Reviewer | ${mdTableCell(item.reviewer || "(no name)")} |`);
-  lines.push(`| Page | ${page.url ? `[${mdTableCell(page.title || page.url)}](${page.url})` : mdTableCell(page.title || "(unknown)")} |`);
+  lines.push(`| Page | ${pageLink ? `[${mdTableCell(page.title || page.url)}](${pageLink})` : mdTableCell(page.title || page.url || "(unknown)")} |`);
   lines.push(`| Target | ${mdTableCell(formatTarget(target))} |`);
   lines.push(`| Selector | \`${String(target.selector || "(none)").replaceAll("\`", "'")}\` |`);
   lines.push(`| Viewport | ${mdTableCell(formatViewport(env.viewport))} |`);
@@ -621,6 +622,22 @@ function escapeHtml(value) {
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
+}
+
+// escapeHtml cannot stop a javascript: URL inside an href attribute; only
+// plain http(s) targets may become links. Returns "" for everything else.
+function safeLinkUrl(value) {
+  const url = String(value || "").trim();
+  return /^https?:\/\//i.test(url) ? url : "";
+}
+
+// Markdown link destinations are wrapped in <> so spaces and parentheses
+// cannot terminate the link; encode the characters that end the <> form so
+// user-controlled URLs cannot break out into raw markdown.
+function mdLinkUrl(value) {
+  const url = safeLinkUrl(value);
+  if (!url) return "";
+  return `<${url.replaceAll("<", "%3C").replaceAll(">", "%3E").replace(/\s/g, "%20")}>`;
 }
 
 async function deliverToSlack(item) {
@@ -1071,7 +1088,7 @@ function renderInbox(items) {
         <p class="comment">${comment}</p>
         ${renderScreenshotPreview(screenshot)}
         <dl>
-          <div><dt>URL</dt><dd><a href="${pageUrl}" target="_blank" rel="noopener">${pageUrl}</a></dd></div>
+          <div><dt>URL</dt><dd>${safeLinkUrl(page.url) ? `<a href="${escapeHtml(safeLinkUrl(page.url))}" target="_blank" rel="noopener">${pageUrl}</a>` : pageUrl}</dd></div>
           <div><dt>Title</dt><dd>${pageTitle}</dd></div>
           <div><dt>Selector</dt><dd><code>${selector}</code></dd></div>
           <div><dt>Viewport</dt><dd>${escapeHtml(viewport)}</dd></div>
@@ -1200,8 +1217,9 @@ function renderFilterPanel(items) {
 function renderGitHubCell(github, id) {
   if (github && github.status === "created") {
     const number = github.issueNumber != null ? `#${escapeHtml(String(github.issueNumber))}` : "issue";
-    return github.url
-      ? `<a href="${escapeHtml(github.url)}" target="_blank" rel="noopener">${number} created</a>`
+    const url = safeLinkUrl(github.url);
+    return url
+      ? `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${number} created</a>`
       : `${number} created`;
   }
 
@@ -1330,8 +1348,8 @@ function renderImportScript() {
 
 function renderScreenshotPreview(screenshot) {
   if (!screenshot) return "";
-  if (screenshot.status === "saved" && screenshot.url) {
-    const url = escapeHtml(screenshot.url);
+  if (screenshot.status === "saved" && safeLinkUrl(screenshot.url)) {
+    const url = escapeHtml(safeLinkUrl(screenshot.url));
     const size = screenshot.width && screenshot.height
       ? `${screenshot.width}×${screenshot.height}`
       : "";

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -217,6 +217,44 @@ function startMockGitHub(t, respond) {
   });
 }
 
+test("user-controlled URLs are linked only when they are http(s)", async (t) => {
+  const github = await startMockGitHub(t, (res) => {
+    res.writeHead(201, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ number: 1, html_url: "https://github.com/acme/demo/issues/1" }));
+  });
+  const receiver = await startReceiver(t, {
+    GITHUB_TOKEN: "test-token",
+    GITHUB_REPO: "acme/demo",
+    GITHUB_API_BASE: github.baseUrl
+  });
+
+  const evil = feedbackPayload("pl_xss_1");
+  evil.page.url = "javascript:alert(document.domain)";
+  await postJson(`${receiver.baseUrl}/feedback`, evil);
+
+  const tricky = feedbackPayload("pl_xss_2");
+  tricky.page.url = "https://example.test/a b) [evil](https://evil.test";
+  await postJson(`${receiver.baseUrl}/feedback`, tricky);
+
+  const normal = feedbackPayload("pl_xss_3");
+  await postJson(`${receiver.baseUrl}/feedback`, normal);
+
+  const inboxHtml = await fetch(`${receiver.baseUrl}/`).then((response) => response.text());
+  assert.ok(!inboxHtml.includes('href="javascript:'), "javascript: URL must not become a link");
+  assert.match(inboxHtml, /javascript:alert\(document\.domain\)/, "rejected URL is still shown as text");
+  assert.ok(inboxHtml.includes('href="http://example.test/demo"'), "http URLs stay linked");
+
+  // GitHub issue body: markdown link only for http(s), wrapped so it cannot break out
+  await postJson(`${receiver.baseUrl}/feedback/pl_xss_2/github-issue`, {});
+  const trickyBody = github.requests[0].body.body;
+  assert.match(trickyBody, /\| Page \| \[.*\]\(<https:\/\/example\.test\/a%20b\)/);
+  assert.ok(!trickyBody.includes("[evil](https://evil.test)"), "URL must not escape the link destination");
+
+  await postJson(`${receiver.baseUrl}/feedback/pl_xss_1/github-issue`, {});
+  const evilBody = github.requests[1].body.body;
+  assert.ok(!evilBody.includes("](javascript:"), "javascript: URL must not become a markdown link");
+});
+
 test("POST /feedback/:id/status rejects unknown statuses and ids", async (t) => {
   const receiver = await startReceiver(t);
   const payload = feedbackPayload("pl_status_2");


### PR DESCRIPTION
## 概要

Closes #48

- **inbox の stored XSS 修正**: `page.url` が `javascript:` スキームでもクリック可能なリンクとして描画されていた。http(s) 以外はプレーンテキスト表示に変更（URL 自体は引き続き確認できる）
- **GitHub issue body の markdown 注入修正**: link 先 URL を `<>` で包み、終端文字（`<` `>` 空白）をエンコード。`)` 等を含む URL で markdown を壊せなくなる。http(s) 以外の `page.url` は title / URL のテキスト表示
- 防御の徹底として、手編集された store に備えて `github.url` / `screenshot.url` の href にも同じガードを適用

## 動作確認

テスト追加（計 9 件、全パス）: `javascript:` URL → inbox に `href=\"javascript:` が出ない + テキストとしては表示される / 正常 URL はリンク維持 / `)` と空白入り URL の issue body 上のエスケープ / `javascript:` URL が markdown link にならない、を実 HTTP で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)