### PR TITLE
編集中断後の新規コメントが既存 feedback を上書きするのを直す

### DIFF
--- a/widget/patchloop-widget.js
+++ b/widget/patchloop-widget.js
@@ -216,6 +216,9 @@
     const target = document.elementFromPoint(start.clientX, start.clientY) || state.drag.target;
 
     discardPendingMarker();
+    // A new capture supersedes an interrupted edit; a stale editingId would
+    // route the submit into the edit branch and silently overwrite that item.
+    state.editingId = null;
 
     let marker;
     if (state.drag.isDragging) {


### PR DESCRIPTION
## 概要

Closes #49

「編集」で開いたフォームを送信せず、コメントモードを開始して新しい場所を capture すると、`editingId` が残ったままのため送信が編集分岐に入り、**編集対象だった古い feedback を黙って上書き**し、新しく置いたマーカーが未番号の孤児として残るバグの修正です。

## 変更内容

- `handleDocumentMouseUp` で新規 capture 開始時に `state.editingId` をクリア（新規 capture は中断された編集に優先する）

## 動作確認（headless Chrome + CDP、issue の再現手順そのまま）

feedback 2 件作成 → 1 件目の「編集」を開く → 送信せずコメントモード開始 → 新しい場所に 3 件目を送信:

- 修正後: **count=3**、1 件目の本文は無傷、pin 3 個すべて番号付き（孤児なし）
- 修正前の挙動（コード上の経路）: count=2 のまま 1 件目が上書きされ、未番号 pin が残留
- `npm run check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)