### PR TITLE
widget/receiver の共有 format モジュール化（Slack 整形・escape の重複解消）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,6 +18,8 @@ http://localhost:4173/examples/plain-html/
 
 ## Development
 
+Node.js 22.12 or later is required (the receiver loads the shared ES module via `require()`).
+
 Install dependencies.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ http://localhost:4173/examples/plain-html/
 
 ## 開発
 
+Node.js 22.12 以上が必要です（receiver が共有 ES module を `require()` で読み込むため）。
+
 依存を入れます。
 
 ```sh

--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -217,9 +217,71 @@ function textFor(element) {
 
 return { cssEscape, selectorFor, textFor };
 })();
+// --- shared/format.js ---
+const __pl_shared_format = (() => {
+// Formatting helpers shared by the widget (bundled into dist) and the
+// receiver (require(ESM) from CommonJS). Environment-free by design: plain
+// string/number formatting only, no DOM and no Node APIs. Receiver-specific
+// link hardening (safeLinkUrl / mdLinkUrl) and the screenshot status texts
+// stay in their respective owners because their semantics differ per side.
+
+function truncateText(value, max) {
+  const text = String(value ?? "");
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function present(value) {
+  return value === undefined || value === null || value === "" ? "?" : value;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function escapeXml(value) {
+  return escapeHtml(value).replaceAll("'", "&apos;");
+}
+
+function slackEscape(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function formatSlackCode(value) {
+  return `\`${slackEscape(truncateText(String(value ?? "").replaceAll("`", "'"), 180))}\``;
+}
+
+function formatSlackLink(url, label) {
+  if (!/^https?:\/\//.test(url || "")) {
+    return slackEscape(label || url || "(unknown)");
+  }
+  return `<${slackEscape(url)}|${slackEscape(truncateText(String(label || url).replaceAll("|", "/"), 120))}>`;
+}
+
+function formatViewport(viewport) {
+  if (!viewport) return "(unknown)";
+  return `${present(viewport.width)}x${present(viewport.height)}`;
+}
+
+function formatTarget(target) {
+  if (target.kind === "area" && target.area) {
+    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
+  }
+  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
+}
+
+return { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget };
+})();
 const { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarget, rectFromStoredArea, round, numberOrNull } = __pl_widget_src_geometry;
 const { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } = __pl_widget_src_anchoring;
 const { selectorFor, textFor } = __pl_widget_src_selector;
+const { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } = __pl_shared_format;
 
 const DEFAULTS = {
   projectId: "local-demo",
@@ -1146,8 +1208,8 @@ function buildSlackWebhookPayload(payload) {
       fields: [
         { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(payload.reviewer || "(no name)")}` },
         { type: "mrkdwn", text: `*Page*\n${formatSlackLink(page.url, page.title || page.url || "(unknown page)")}` },
-        { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTargetForSlack(target))}` },
-        { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewportForSlack(env.viewport))}` },
+        { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTarget(target))}` },
+        { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewport(env.viewport))}` },
         { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
         { type: "mrkdwn", text: `*Created*\n${slackEscape(payload.createdAt || "(unknown)")}` }
       ]
@@ -1192,36 +1254,6 @@ function buildSlackWebhookPayload(payload) {
   };
 }
 
-function slackEscape(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
-
-function formatSlackCode(value) {
-  return `\`${slackEscape(truncateText(String(value ?? "").replaceAll("`", "'"), 180))}\``;
-}
-
-function formatSlackLink(url, label) {
-  if (!/^https?:\/\//.test(url || "")) {
-    return slackEscape(label || url || "(unknown)");
-  }
-  return `<${slackEscape(url)}|${slackEscape(truncateText(String(label || url).replaceAll("|", "/"), 120))}>`;
-}
-
-function formatViewportForSlack(viewport) {
-  if (!viewport) return "(unknown)";
-  return `${present(viewport.width)}x${present(viewport.height)}`;
-}
-
-function formatTargetForSlack(target) {
-  if (target.kind === "area" && target.area) {
-    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
-  }
-  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
-}
-
 function formatDirectScreenshotStatus(screenshot) {
   if (screenshot.status === "captured") {
     return "captured locally; direct Slack mode needs a public image URL";
@@ -1230,15 +1262,6 @@ function formatDirectScreenshotStatus(screenshot) {
     return `omitted: ${present(screenshot.bytes)} bytes exceeds ${present(screenshot.maxBytes)}`;
   }
   return screenshot.status || "unknown";
-}
-
-function truncateText(value, max) {
-  const text = String(value ?? "");
-  return text.length > max ? `${text.slice(0, max)}…` : text;
-}
-
-function present(value) {
-  return value === undefined || value === null || value === "" ? "?" : value;
 }
 
 function addPin(point) {
@@ -1801,18 +1824,6 @@ function addArea(rect) {
 
 function getRoot() {
   return document.querySelector("[data-patchloop-root]");
-}
-
-function escapeHtml(value) {
-  return String(value || "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-function escapeXml(value) {
-  return escapeHtml(value).replaceAll("'", "&apos;");
 }
 
 function injectStyles() {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,6 +90,17 @@ module.exports = [
     rules: sharedRules
   },
   {
+    // Shared by widget (browser) and receiver (Node): environment-free code
+    // only, so no host globals are provided on purpose.
+    files: ["shared/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: "module",
+      globals: {}
+    },
+    rules: sharedRules
+  },
+  {
     files: ["widget/**/*.js"],
     languageOptions: {
       ecmaVersion: 2024,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "description": "Browser feedback widget and local receiver prototype.",
+  "engines": {
+    "node": ">=22.12"
+  },
   "scripts": {
     "start": "node server/receive.js",
     "build": "node scripts/build.js",

--- a/server/receive.js
+++ b/server/receive.js
@@ -5,6 +5,8 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 
+const { truncateText, present, escapeHtml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } = require("../shared/format.js");
+
 const CONFIG_PATH = process.env.PATCHLOOP_RECEIVER_CONFIG || path.join(__dirname, "receiver.config.json");
 const config = loadConfig(CONFIG_PATH);
 const configDir = path.dirname(CONFIG_PATH);
@@ -168,7 +170,7 @@ function handlePostFeedback(req, res) {
     const slackLog = stored.integrations.slack.status === "disabled"
       ? ""
       : ` slack=${stored.integrations.slack.status}`;
-    console.log(`[PatchLoop receiver] received feedback id=${payload?.id || "?"} comment="${truncate(payload?.comment || "", 60)}"${slackLog}`);
+    console.log(`[PatchLoop receiver] received feedback id=${payload?.id || "?"} comment="${truncateText(payload?.comment || "", 60)}"${slackLog}`);
     respondJson(res, 201, {
       ok: true,
       id: payload?.id,
@@ -204,7 +206,7 @@ function handlePostImport(req, res) {
 
     feedback.unshift(stored);
     persist();
-    console.log(`[PatchLoop receiver] imported feedback id=${stored.id || "?"} comment="${truncate(stored.comment || "", 60)}"`);
+    console.log(`[PatchLoop receiver] imported feedback id=${stored.id || "?"} comment="${truncateText(stored.comment || "", 60)}"`);
     respondJson(res, 201, {
       ok: true,
       id: stored.id,
@@ -300,7 +302,7 @@ async function createGitHubIssue(item) {
     return {
       status: "failed",
       statusCode: response.statusCode,
-      error: truncate(gitHubErrorMessage(response.body) || "GitHub API returned a non-201 response", 240),
+      error: truncateText(gitHubErrorMessage(response.body) || "GitHub API returned a non-201 response", 240),
       failedAt: new Date().toISOString()
     };
   } catch (error) {
@@ -318,7 +320,7 @@ function gitHubErrorMessage(raw) {
 
 function gitHubIssueTitle(item) {
   const firstLine = String(item.comment || "").split("\n")[0].trim() || "(no comment)";
-  return `[PatchLoop] ${truncate(firstLine, 80)}`;
+  return `[PatchLoop] ${truncateText(firstLine, 80)}`;
 }
 
 function gitHubIssueBody(item) {
@@ -343,7 +345,7 @@ function gitHubIssueBody(item) {
 
   if (target.text) {
     lines.push("### Element text", "");
-    lines.push(...truncate(String(target.text), 500).split("\n").map((line) => `> ${line}`), "");
+    lines.push(...truncateText(String(target.text), 500).split("\n").map((line) => `> ${line}`), "");
   }
 
   const screenshotUrl = screenshotUrlFor(item.screenshot);
@@ -657,18 +659,6 @@ function respondJson(res, status, body) {
   res.end(JSON.stringify(body));
 }
 
-function truncate(value, max) {
-  return value.length > max ? `${value.slice(0, max)}…` : value;
-}
-
-function escapeHtml(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
 // escapeHtml cannot stop a javascript: URL inside an href attribute; only
 // plain http(s) targets may become links. Returns "" for everything else.
 function safeLinkUrl(value) {
@@ -704,7 +694,7 @@ async function deliverToSlack(item) {
       : {
           status: "failed",
           statusCode: response.statusCode,
-          error: truncate(response.body || "Slack webhook returned a non-2xx response", 240)
+          error: truncateText(response.body || "Slack webhook returned a non-2xx response", 240)
         };
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -808,7 +798,7 @@ async function maybeUploadScreenshotToSlack(item) {
       return {
         status: "failed",
         statusCode: uploadResponse.statusCode,
-        error: truncate(uploadResponse.body || "upload_url returned a non-2xx response", 240)
+        error: truncateText(uploadResponse.body || "upload_url returned a non-2xx response", 240)
       };
     }
 
@@ -924,7 +914,7 @@ function buildSlackMessage(item) {
   const target = item.target || {};
   const env = item.environment || {};
   const page = item.page || {};
-  const comment = slackEscape(truncate(item.comment || "(empty comment)", 1400));
+  const comment = slackEscape(truncateText(item.comment || "(empty comment)", 1400));
   const screenshotUrl = screenshotUrlFor(item.screenshot);
   const pageText = page.url
     ? formatSlackLink(page.url, page.title || page.url)
@@ -963,7 +953,7 @@ function buildSlackMessage(item) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Element text*\n>${slackEscape(truncate(target.text, 500)).replaceAll("\n", "\n>")}`
+        text: `*Element text*\n>${slackEscape(truncateText(target.text, 500)).replaceAll("\n", "\n>")}`
       }
     });
   }
@@ -1008,27 +998,9 @@ function buildSlackMessage(item) {
   });
 
   return {
-    text: `PatchLoop feedback: ${truncate(item.comment || "", 120)}`,
+    text: `PatchLoop feedback: ${truncateText(item.comment || "", 120)}`,
     blocks
   };
-}
-
-function slackEscape(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
-
-function formatSlackCode(value) {
-  return `\`${slackEscape(truncate(String(value ?? "").replaceAll("`", "'"), 180))}\``;
-}
-
-function formatSlackLink(url, label) {
-  if (!/^https?:\/\//.test(url)) {
-    return slackEscape(url);
-  }
-  return `<${slackEscape(url)}|${slackEscape(truncate(String(label).replaceAll("|", "/"), 120))}>`;
 }
 
 function screenshotUrlFor(screenshot) {
@@ -1069,22 +1041,6 @@ function shouldSendSlackImageBlock(screenshotUrl) {
   }
   if (SLACK_IMAGE_MODE === "block") return /^https?:\/\//.test(screenshotUrl);
   return isLikelyPublicHttpUrl(screenshotUrl);
-}
-
-function formatViewport(viewport) {
-  if (!viewport) return "(unknown)";
-  return `${present(viewport.width)}x${present(viewport.height)}`;
-}
-
-function formatTarget(target) {
-  if (target.kind === "area" && target.area) {
-    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
-  }
-  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
-}
-
-function present(value) {
-  return value === undefined || value === null || value === "" ? "?" : value;
 }
 
 function feedbackStatusOf(item) {

--- a/shared/format.js
+++ b/shared/format.js
@@ -1,0 +1,56 @@
+// Formatting helpers shared by the widget (bundled into dist) and the
+// receiver (require(ESM) from CommonJS). Environment-free by design: plain
+// string/number formatting only, no DOM and no Node APIs. Receiver-specific
+// link hardening (safeLinkUrl / mdLinkUrl) and the screenshot status texts
+// stay in their respective owners because their semantics differ per side.
+
+export function truncateText(value, max) {
+  const text = String(value ?? "");
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export function present(value) {
+  return value === undefined || value === null || value === "" ? "?" : value;
+}
+
+export function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function escapeXml(value) {
+  return escapeHtml(value).replaceAll("'", "&apos;");
+}
+
+export function slackEscape(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function formatSlackCode(value) {
+  return `\`${slackEscape(truncateText(String(value ?? "").replaceAll("`", "'"), 180))}\``;
+}
+
+export function formatSlackLink(url, label) {
+  if (!/^https?:\/\//.test(url || "")) {
+    return slackEscape(label || url || "(unknown)");
+  }
+  return `<${slackEscape(url)}|${slackEscape(truncateText(String(label || url).replaceAll("|", "/"), 120))}>`;
+}
+
+export function formatViewport(viewport) {
+  if (!viewport) return "(unknown)";
+  return `${present(viewport.width)}x${present(viewport.height)}`;
+}
+
+export function formatTarget(target) {
+  if (target.kind === "area" && target.area) {
+    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
+  }
+  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/shared-format.test.js
+++ b/test/shared-format.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  truncateText,
+  present,
+  escapeHtml,
+  escapeXml,
+  slackEscape,
+  formatSlackCode,
+  formatSlackLink,
+  formatViewport,
+  formatTarget
+} = require("../shared/format.js");
+
+test("truncateText coerces and appends an ellipsis past the limit", () => {
+  assert.equal(truncateText("hello", 10), "hello");
+  assert.equal(truncateText("hello world", 5), "hello…");
+  assert.equal(truncateText(null, 5), "");
+  assert.equal(truncateText(12345678, 4), "1234…");
+});
+
+test("present substitutes ? for empty values only", () => {
+  assert.equal(present("x"), "x");
+  assert.equal(present(0), 0);
+  assert.equal(present(false), false);
+  assert.equal(present(""), "?");
+  assert.equal(present(null), "?");
+  assert.equal(present(undefined), "?");
+});
+
+test("escapeHtml escapes markup characters and keeps falsy non-nullish values", () => {
+  assert.equal(escapeHtml('<a href="x">&</a>'), "&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;");
+  assert.equal(escapeHtml(0), "0");
+  assert.equal(escapeHtml(null), "");
+  assert.equal(escapeHtml(undefined), "");
+});
+
+test("escapeXml additionally escapes single quotes", () => {
+  assert.equal(escapeXml("it's <b>"), "it&apos;s &lt;b&gt;");
+});
+
+test("slackEscape escapes Slack mrkdwn control characters", () => {
+  assert.equal(slackEscape("<&>"), "&lt;&amp;&gt;");
+  assert.equal(slackEscape(null), "");
+});
+
+test("formatSlackCode wraps in backticks, replaces inner backticks, truncates at 180", () => {
+  assert.equal(formatSlackCode("a`b"), "`a'b`");
+  const long = formatSlackCode("x".repeat(200));
+  assert.ok(long.startsWith("`"));
+  assert.ok(long.endsWith("…`"));
+  assert.equal(long.length, 180 + 3); // 180 chars + ellipsis + 2 backticks
+});
+
+test("formatSlackLink links http(s) URLs and degrades to escaped text otherwise", () => {
+  assert.equal(formatSlackLink("https://a.test/x", "Label"), "<https://a.test/x|Label>");
+  // pipe would terminate the Slack link syntax
+  assert.equal(formatSlackLink("https://a.test/x", "a|b"), "<https://a.test/x|a/b>");
+  // label falls back to the URL
+  assert.equal(formatSlackLink("https://a.test/x", ""), "<https://a.test/x|https://a.test/x>");
+  // non-http schemes never become links
+  assert.equal(formatSlackLink("javascript:alert(1)", "click"), "click");
+  assert.equal(formatSlackLink(null, "page title"), "page title");
+  assert.equal(formatSlackLink(null, null), "(unknown)");
+});
+
+test("formatViewport renders width x height with placeholders", () => {
+  assert.equal(formatViewport({ width: 1024, height: 768 }), "1024x768");
+  assert.equal(formatViewport({ width: 1024 }), "1024x?");
+  assert.equal(formatViewport(null), "(unknown)");
+});
+
+test("formatTarget describes points and areas", () => {
+  assert.equal(formatTarget({ kind: "point", clientX: 10, clientY: 20 }), "point at 10,20");
+  assert.equal(formatTarget({}), "point at ?,?");
+  assert.equal(
+    formatTarget({ kind: "area", area: { clientWidth: 100, clientHeight: 50, clientX: 5, clientY: 6 } }),
+    "area 100x50 at 5,6"
+  );
+  // area kind without area payload falls back to point formatting
+  assert.equal(formatTarget({ kind: "area", clientX: 1, clientY: 2 }), "area at 1,2");
+});

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -1,6 +1,7 @@
 import { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarget, rectFromStoredArea, round, numberOrNull } from "./geometry.js";
 import { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } from "./anchoring.js";
 import { selectorFor, textFor } from "./selector.js";
+import { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } from "../../shared/format.js";
 
 const DEFAULTS = {
   projectId: "local-demo",
@@ -927,8 +928,8 @@ function buildSlackWebhookPayload(payload) {
       fields: [
         { type: "mrkdwn", text: `*Reviewer*\n${slackEscape(payload.reviewer || "(no name)")}` },
         { type: "mrkdwn", text: `*Page*\n${formatSlackLink(page.url, page.title || page.url || "(unknown page)")}` },
-        { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTargetForSlack(target))}` },
-        { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewportForSlack(env.viewport))}` },
+        { type: "mrkdwn", text: `*Target*\n${slackEscape(formatTarget(target))}` },
+        { type: "mrkdwn", text: `*Viewport*\n${slackEscape(formatViewport(env.viewport))}` },
         { type: "mrkdwn", text: `*Selector*\n${formatSlackCode(target.selector || "(none)")}` },
         { type: "mrkdwn", text: `*Created*\n${slackEscape(payload.createdAt || "(unknown)")}` }
       ]
@@ -973,36 +974,6 @@ function buildSlackWebhookPayload(payload) {
   };
 }
 
-function slackEscape(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
-
-function formatSlackCode(value) {
-  return `\`${slackEscape(truncateText(String(value ?? "").replaceAll("`", "'"), 180))}\``;
-}
-
-function formatSlackLink(url, label) {
-  if (!/^https?:\/\//.test(url || "")) {
-    return slackEscape(label || url || "(unknown)");
-  }
-  return `<${slackEscape(url)}|${slackEscape(truncateText(String(label || url).replaceAll("|", "/"), 120))}>`;
-}
-
-function formatViewportForSlack(viewport) {
-  if (!viewport) return "(unknown)";
-  return `${present(viewport.width)}x${present(viewport.height)}`;
-}
-
-function formatTargetForSlack(target) {
-  if (target.kind === "area" && target.area) {
-    return `area ${present(target.area.clientWidth)}x${present(target.area.clientHeight)} at ${present(target.area.clientX)},${present(target.area.clientY)}`;
-  }
-  return `${target.kind || "point"} at ${present(target.clientX)},${present(target.clientY)}`;
-}
-
 function formatDirectScreenshotStatus(screenshot) {
   if (screenshot.status === "captured") {
     return "captured locally; direct Slack mode needs a public image URL";
@@ -1011,15 +982,6 @@ function formatDirectScreenshotStatus(screenshot) {
     return `omitted: ${present(screenshot.bytes)} bytes exceeds ${present(screenshot.maxBytes)}`;
   }
   return screenshot.status || "unknown";
-}
-
-function truncateText(value, max) {
-  const text = String(value ?? "");
-  return text.length > max ? `${text.slice(0, max)}…` : text;
-}
-
-function present(value) {
-  return value === undefined || value === null || value === "" ? "?" : value;
 }
 
 function addPin(point) {
@@ -1582,18 +1544,6 @@ function addArea(rect) {
 
 function getRoot() {
   return document.querySelector("[data-patchloop-root]");
-}
-
-function escapeHtml(value) {
-  return String(value || "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-function escapeXml(value) {
-  return escapeHtml(value).replaceAll("'", "&apos;");
 }
 
 function injectStyles() {


### PR DESCRIPTION
Closes #61

## 変更内容
- `shared/format.js`（ESM・環境非依存）を新設し、widget / receiver でほぼコピーだった整形ヘルパーを集約: `truncateText` / `present` / `escapeHtml` / `escapeXml` / `slackEscape` / `formatSlackCode` / `formatSlackLink` / `formatViewport` / `formatTarget`
- widget はバンドラー経由（`../../shared/format.js` を import、#59 の簡易バンドラーがそのまま解決）、receiver は `require(ESM)`（Node 25）で利用。`shared/package.json` に `type: module`
- **意味が違うものは共有しない**: スクショ状態表示（widget = direct mode / receiver = saved）、receiver の `safeLinkUrl` / `mdLinkUrl`（GitHub issue 用のリンク無害化、PR #57 の領域）はそれぞれの側に残置
- 微妙に実装が割れていた 3 つは頑健な方に統一（= 意図的な軽微の挙動統一）:
  - `truncateText`: widget 版を採用（非文字列を coerce。旧 receiver 版は string 前提）
  - `formatSlackLink`: widget 版を採用（URL 欠落時に label 優先で表示。非 http はリンク化しない点は両者同じ）
  - `escapeHtml`: receiver 版を採用（`??` — 0 や false が空文字に化けない）
- ESLint に `shared/**`（ESM・ホスト globals なし）ブロックを追加

## 検証
- `npm run check` 全パス（ESLint + dist 鮮度 + テスト **43 件** = receiver 11 + widget 23 + shared 新規 9）
- shared のテストは統一後セマンティクスを固定（非 http / null URL のリンク化拒否、pipe 置換、0 の保持など）
- receiver はテストで実 spawn されるため require(ESM) 経路も実証済み
- headless Chrome スモークテスト 14 項目全パス（マウント〜送信〜reload 復元〜resize 再アンカー）