### PR TITLE
マウス入力の堅牢化: ボタン種別チェックと ghost selection box

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -455,6 +455,9 @@ function bindGlobalCapture() {
 
 function handleDocumentMouseDown(event) {
   if (!state.active) return;
+  // Secondary/middle buttons keep their native behavior (context menu,
+  // autoscroll); capturing them would drop a pin under the context menu.
+  if (event.button !== 0) return;
   if (event.target.closest("[data-patchloop-root]")) return;
 
   event.preventDefault();
@@ -471,6 +474,15 @@ function handleDocumentMouseDown(event) {
 
 function handleDocumentMouseMove(event) {
   if (!state.active || !state.drag) return;
+  // The mouseup can be missed entirely (button released outside the
+  // window); event.buttons reports what is actually held, so a move
+  // without the primary button cancels the drag instead of dragging
+  // a ghost selection box around.
+  if ((event.buttons & 1) === 0) {
+    removeSelectionBox();
+    state.drag = null;
+    return;
+  }
   if (event.target.closest("[data-patchloop-root]")) return;
 
   event.preventDefault();
@@ -487,7 +499,11 @@ function handleDocumentMouseMove(event) {
 
 function handleDocumentMouseUp(event) {
   if (!state.active || !state.drag) return;
-  if (event.target.closest("[data-patchloop-root]")) return;
+  if (event.target.closest("[data-patchloop-root]")) {
+    removeSelectionBox();
+    state.drag = null;
+    return;
+  }
 
   event.preventDefault();
   event.stopPropagation();
@@ -590,8 +606,8 @@ function openCommentForm(point, options = {}) {
   const form = getRoot().querySelector("[data-pl-comment]");
   form.hidden = false;
   clearFormError(form);
-  form.style.left = `${Math.min(point.clientX + 14, window.innerWidth - 340)}px`;
-  form.style.top = `${Math.min(point.clientY + 14, window.innerHeight - 250)}px`;
+  form.style.left = `${Math.max(8, Math.min(point.clientX + 14, window.innerWidth - 340))}px`;
+  form.style.top = `${Math.max(8, Math.min(point.clientY + 14, window.innerHeight - 250))}px`;
   const commentEl = form.querySelector("[data-pl-comment-text]");
   const reviewerEl = form.querySelector("[data-pl-reviewer]");
   commentEl.value = options.comment != null ? options.comment : "";

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -175,6 +175,9 @@ function bindGlobalCapture() {
 
 function handleDocumentMouseDown(event) {
   if (!state.active) return;
+  // Secondary/middle buttons keep their native behavior (context menu,
+  // autoscroll); capturing them would drop a pin under the context menu.
+  if (event.button !== 0) return;
   if (event.target.closest("[data-patchloop-root]")) return;
 
   event.preventDefault();
@@ -191,6 +194,15 @@ function handleDocumentMouseDown(event) {
 
 function handleDocumentMouseMove(event) {
   if (!state.active || !state.drag) return;
+  // The mouseup can be missed entirely (button released outside the
+  // window); event.buttons reports what is actually held, so a move
+  // without the primary button cancels the drag instead of dragging
+  // a ghost selection box around.
+  if ((event.buttons & 1) === 0) {
+    removeSelectionBox();
+    state.drag = null;
+    return;
+  }
   if (event.target.closest("[data-patchloop-root]")) return;
 
   event.preventDefault();
@@ -207,7 +219,11 @@ function handleDocumentMouseMove(event) {
 
 function handleDocumentMouseUp(event) {
   if (!state.active || !state.drag) return;
-  if (event.target.closest("[data-patchloop-root]")) return;
+  if (event.target.closest("[data-patchloop-root]")) {
+    removeSelectionBox();
+    state.drag = null;
+    return;
+  }
 
   event.preventDefault();
   event.stopPropagation();
@@ -310,8 +326,8 @@ function openCommentForm(point, options = {}) {
   const form = getRoot().querySelector("[data-pl-comment]");
   form.hidden = false;
   clearFormError(form);
-  form.style.left = `${Math.min(point.clientX + 14, window.innerWidth - 340)}px`;
-  form.style.top = `${Math.min(point.clientY + 14, window.innerHeight - 250)}px`;
+  form.style.left = `${Math.max(8, Math.min(point.clientX + 14, window.innerWidth - 340))}px`;
+  form.style.top = `${Math.max(8, Math.min(point.clientY + 14, window.innerHeight - 250))}px`;
   const commentEl = form.querySelector("[data-pl-comment-text]");
   const reviewerEl = form.querySelector("[data-pl-reviewer]");
   commentEl.value = options.comment != null ? options.comment : "";


### PR DESCRIPTION
Closes #52

issue 記載の 3 項目すべてに対応:

1. **ボタン種別**: `handleDocumentMouseDown` で `event.button !== 0` を無視。右クリック・中クリックはネイティブ挙動（コンテキストメニュー等）のまま
2. **ghost selection box**: 2 経路とも修正
   - widget パネル上で mouseup → drag と選択枠を破棄（従来は早期 return で `state.drag` が残存）
   - ウィンドウ外でボタンを離して mouseup を取りこぼした場合 → 次の mousemove の `event.buttons` で主ボタン解放を検知してキャンセル
3. **コメントフォームのクランプ**: 左・上端にも下限（8px）を追加。狭い viewport で画面外に出ない

## 検証
- `npm run check` 全パス（48 件）
- headless Chrome で専用スモーク 8 項目全パス（右クリック無視 / パネル上 mouseup 後にゴースト枠なし / buttons=0 move でキャンセル / 320px viewport でフォーム位置 left=8,top=16 にクランプ / 通常の点キャプチャは従来どおり）
- 既存の widget スモーク 14 項目も全パス（リグレッションなし）

⚠️ 他の widget 系 PR（#51/#54 対応分）と `dist/patchloop-widget.js` が衝突します。merge 順は任意ですが、後続 PR は merge のたびに rebase + `npm run build` で更新します。