### PR TITLE
低優先まとめ #54 から即対応可能な 5 件（id 衝突 / destroy / Slack direct 表示 / Safari / init 二重呼び）

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -319,6 +319,19 @@ const state = {
 };
 
 function init(options = {}) {
+  // From <head> there is no body yet to mount into; retry once the DOM is ready.
+  if (!document.body) {
+    document.addEventListener("DOMContentLoaded", () => init(options), { once: true });
+    return api;
+  }
+  // Re-init while comment mode is on must not leave stale mode state
+  // (crosshair cursor, active drag) behind the freshly rendered UI.
+  state.active = false;
+  document.documentElement.classList.remove("pl-feedback-active");
+  state.drag = null;
+  state.pendingTarget = null;
+  state.editingId = null;
+  removeSelectionBox();
   state.options = { ...DEFAULTS, ...options };
   state.options.reviewer = initialReviewer(state.options);
   injectStyles();
@@ -331,6 +344,8 @@ function init(options = {}) {
 }
 
 function destroy() {
+  document.documentElement.classList.remove("pl-feedback-active");
+  document.querySelector("[data-patchloop-style]")?.remove();
   document.removeEventListener("mousedown", handleDocumentMouseDown, true);
   document.removeEventListener("mousemove", handleDocumentMouseMove, true);
   document.removeEventListener("mouseup", handleDocumentMouseUp, true);
@@ -627,7 +642,14 @@ function closeCommentForm() {
 function handleCommentKeydown(event) {
   if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
   event.preventDefault();
-  event.currentTarget.requestSubmit();
+  const form = event.currentTarget;
+  if (typeof form.requestSubmit === "function") {
+    form.requestSubmit();
+  } else {
+    // Safari 15 has no requestSubmit; clicking the submit button keeps
+    // the submit event (and its validation) on the same path.
+    form.querySelector('button[type="submit"]')?.click();
+  }
 }
 
 function handleDeliverySettingsInput() {
@@ -722,7 +744,7 @@ async function submitComment(event) {
 
 function buildPayload(comment, reviewer, target) {
   return {
-    id: `pl_${Date.now()}`,
+    id: generateFeedbackId(),
     projectId: state.options.projectId,
     demoId: state.options.demoId,
     comment,
@@ -1192,7 +1214,9 @@ async function postSlackWebhook(payload) {
       headers: { "Content-Type": "text/plain;charset=UTF-8" },
       body: JSON.stringify(buildSlackWebhookPayload(payload))
     });
-    payload.delivery = { ok: true, status: "opaque", target: "slack-webhook" };
+    // no-cors gives an opaque response: we know nothing about the outcome,
+    // so report "unknown" instead of pretending it succeeded.
+    payload.delivery = { ok: null, status: "unknown", target: "slack-webhook" };
   } catch (error) {
     payload.delivery = { ok: false, target: "slack-webhook", error: error.message };
   }
@@ -1216,7 +1240,7 @@ function buildSlackWebhookPayload(payload) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: slackEscape(truncateText(payload.comment || "(empty comment)", 1400))
+        text: truncateText(slackEscape(payload.comment || "(empty comment)"), 1400)
       }
     },
     {
@@ -1237,7 +1261,7 @@ function buildSlackWebhookPayload(payload) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Element text*\n>${slackEscape(truncateText(target.text, 500)).replaceAll("\n", "\n>")}`
+        text: `*Element text*\n>${truncateText(slackEscape(target.text), 500).replaceAll("\n", "\n>")}`
       }
     });
   }
@@ -1637,9 +1661,11 @@ function renderFeedbackList() {
       const num = state.feedback.length - i;
       const kind = (item.target && item.target.kind) || "point";
       const delivery = item.delivery
-        ? item.delivery.ok
-          ? `<span class="pl-feedback-status pl-feedback-status-ok" title="${escapeHtml(deliveryStatusText(item.delivery))}">✓</span>`
-          : `<span class="pl-feedback-status pl-feedback-status-fail" title="${escapeHtml(deliveryStatusText(item.delivery))}">✗</span>`
+        ? item.delivery.ok === null
+          ? `<span class="pl-feedback-status pl-feedback-status-unknown" title="${escapeHtml(deliveryStatusText(item.delivery))}">?</span>`
+          : item.delivery.ok
+            ? `<span class="pl-feedback-status pl-feedback-status-ok" title="${escapeHtml(deliveryStatusText(item.delivery))}">✓</span>`
+            : `<span class="pl-feedback-status pl-feedback-status-fail" title="${escapeHtml(deliveryStatusText(item.delivery))}">✗</span>`
         : "";
       const approximate = state.approximateIds.has(item.id)
         ? '<span class="pl-feedback-approx" title="ウィンドウサイズが変わったため、位置が近似になっています">≈</span>'
@@ -1668,6 +1694,7 @@ function deliveryStatusText(delivery) {
     return `download failed: ${delivery.error || "unknown error"}`;
   }
   if (delivery.target === "slack-webhook") {
+    if (delivery.ok === null) return "posted to Slack direct (result unknown: no-cors)";
     if (delivery.ok) return "sent to Slack direct";
     return `Slack direct failed: ${delivery.error || "unknown error"}`;
   }
@@ -1838,6 +1865,15 @@ function addArea(rect) {
   return { node: area, label };
 }
 
+// Date.now() alone collides across tabs/reviewers within the same
+// millisecond, which also collides marker Map keys and orphans nodes.
+function generateFeedbackId() {
+  const random = globalThis.crypto && typeof globalThis.crypto.randomUUID === "function"
+    ? globalThis.crypto.randomUUID().slice(0, 8)
+    : Math.random().toString(36).slice(2, 10);
+  return `pl_${Date.now()}_${random}`;
+}
+
 function getRoot() {
   return document.querySelector("[data-patchloop-root]");
 }
@@ -1887,6 +1923,7 @@ function injectStyles() {
     .pl-feedback-status { font-weight: 900; }
     .pl-feedback-status-ok { color: #0f7b63; }
     .pl-feedback-status-fail { color: #d1495b; }
+    .pl-feedback-status-unknown { color: #8a9590; }
     .pl-tooltip { position: fixed; max-width: 280px; background: #14211d; color: #fff; padding: 8px 10px; border-radius: 6px; font-size: 12px; line-height: 1.4; pointer-events: none; z-index: 2147483002; box-shadow: 0 12px 30px rgba(20, 33, 29, 0.32); white-space: pre-wrap; word-break: break-word; }
     .pl-comment { position: fixed; z-index: 2147483001; width: min(320px, calc(100vw - 24px)); display: grid; gap: 10px; padding: 14px; background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; box-shadow: 0 22px 70px rgba(20, 33, 29, 0.24); }
     .pl-comment label { display: grid; gap: 6px; color: #65716d; font-size: 12px; font-weight: 800; }

--- a/server/receive.js
+++ b/server/receive.js
@@ -4,6 +4,7 @@ const http = require("http");
 const https = require("https");
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 
 const { truncateText, present, escapeHtml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } = require("../shared/format.js");
 
@@ -657,7 +658,8 @@ function saveScreenshot(screenshot, id) {
   }
 
   fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
-  const fileName = `${safeFilePart(id || "feedback")}-${Date.now()}.${extension}`;
+  const random = crypto.randomUUID().slice(0, 8);
+  const fileName = `${safeFilePart(id || "feedback")}-${Date.now()}-${random}.${extension}`;
   const filePath = path.join(SCREENSHOT_DIR, fileName);
   fs.writeFileSync(filePath, parsed.buffer);
 

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -39,6 +39,19 @@ const state = {
 };
 
 function init(options = {}) {
+  // From <head> there is no body yet to mount into; retry once the DOM is ready.
+  if (!document.body) {
+    document.addEventListener("DOMContentLoaded", () => init(options), { once: true });
+    return api;
+  }
+  // Re-init while comment mode is on must not leave stale mode state
+  // (crosshair cursor, active drag) behind the freshly rendered UI.
+  state.active = false;
+  document.documentElement.classList.remove("pl-feedback-active");
+  state.drag = null;
+  state.pendingTarget = null;
+  state.editingId = null;
+  removeSelectionBox();
   state.options = { ...DEFAULTS, ...options };
   state.options.reviewer = initialReviewer(state.options);
   injectStyles();
@@ -51,6 +64,8 @@ function init(options = {}) {
 }
 
 function destroy() {
+  document.documentElement.classList.remove("pl-feedback-active");
+  document.querySelector("[data-patchloop-style]")?.remove();
   document.removeEventListener("mousedown", handleDocumentMouseDown, true);
   document.removeEventListener("mousemove", handleDocumentMouseMove, true);
   document.removeEventListener("mouseup", handleDocumentMouseUp, true);
@@ -347,7 +362,14 @@ function closeCommentForm() {
 function handleCommentKeydown(event) {
   if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
   event.preventDefault();
-  event.currentTarget.requestSubmit();
+  const form = event.currentTarget;
+  if (typeof form.requestSubmit === "function") {
+    form.requestSubmit();
+  } else {
+    // Safari 15 has no requestSubmit; clicking the submit button keeps
+    // the submit event (and its validation) on the same path.
+    form.querySelector('button[type="submit"]')?.click();
+  }
 }
 
 function handleDeliverySettingsInput() {
@@ -442,7 +464,7 @@ async function submitComment(event) {
 
 function buildPayload(comment, reviewer, target) {
   return {
-    id: `pl_${Date.now()}`,
+    id: generateFeedbackId(),
     projectId: state.options.projectId,
     demoId: state.options.demoId,
     comment,
@@ -912,7 +934,9 @@ async function postSlackWebhook(payload) {
       headers: { "Content-Type": "text/plain;charset=UTF-8" },
       body: JSON.stringify(buildSlackWebhookPayload(payload))
     });
-    payload.delivery = { ok: true, status: "opaque", target: "slack-webhook" };
+    // no-cors gives an opaque response: we know nothing about the outcome,
+    // so report "unknown" instead of pretending it succeeded.
+    payload.delivery = { ok: null, status: "unknown", target: "slack-webhook" };
   } catch (error) {
     payload.delivery = { ok: false, target: "slack-webhook", error: error.message };
   }
@@ -936,7 +960,7 @@ function buildSlackWebhookPayload(payload) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: slackEscape(truncateText(payload.comment || "(empty comment)", 1400))
+        text: truncateText(slackEscape(payload.comment || "(empty comment)"), 1400)
       }
     },
     {
@@ -957,7 +981,7 @@ function buildSlackWebhookPayload(payload) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Element text*\n>${slackEscape(truncateText(target.text, 500)).replaceAll("\n", "\n>")}`
+        text: `*Element text*\n>${truncateText(slackEscape(target.text), 500).replaceAll("\n", "\n>")}`
       }
     });
   }
@@ -1357,9 +1381,11 @@ function renderFeedbackList() {
       const num = state.feedback.length - i;
       const kind = (item.target && item.target.kind) || "point";
       const delivery = item.delivery
-        ? item.delivery.ok
-          ? `<span class="pl-feedback-status pl-feedback-status-ok" title="${escapeHtml(deliveryStatusText(item.delivery))}">✓</span>`
-          : `<span class="pl-feedback-status pl-feedback-status-fail" title="${escapeHtml(deliveryStatusText(item.delivery))}">✗</span>`
+        ? item.delivery.ok === null
+          ? `<span class="pl-feedback-status pl-feedback-status-unknown" title="${escapeHtml(deliveryStatusText(item.delivery))}">?</span>`
+          : item.delivery.ok
+            ? `<span class="pl-feedback-status pl-feedback-status-ok" title="${escapeHtml(deliveryStatusText(item.delivery))}">✓</span>`
+            : `<span class="pl-feedback-status pl-feedback-status-fail" title="${escapeHtml(deliveryStatusText(item.delivery))}">✗</span>`
         : "";
       const approximate = state.approximateIds.has(item.id)
         ? '<span class="pl-feedback-approx" title="ウィンドウサイズが変わったため、位置が近似になっています">≈</span>'
@@ -1388,6 +1414,7 @@ function deliveryStatusText(delivery) {
     return `download failed: ${delivery.error || "unknown error"}`;
   }
   if (delivery.target === "slack-webhook") {
+    if (delivery.ok === null) return "posted to Slack direct (result unknown: no-cors)";
     if (delivery.ok) return "sent to Slack direct";
     return `Slack direct failed: ${delivery.error || "unknown error"}`;
   }
@@ -1558,6 +1585,15 @@ function addArea(rect) {
   return { node: area, label };
 }
 
+// Date.now() alone collides across tabs/reviewers within the same
+// millisecond, which also collides marker Map keys and orphans nodes.
+function generateFeedbackId() {
+  const random = globalThis.crypto && typeof globalThis.crypto.randomUUID === "function"
+    ? globalThis.crypto.randomUUID().slice(0, 8)
+    : Math.random().toString(36).slice(2, 10);
+  return `pl_${Date.now()}_${random}`;
+}
+
 function getRoot() {
   return document.querySelector("[data-patchloop-root]");
 }
@@ -1607,6 +1643,7 @@ function injectStyles() {
     .pl-feedback-status { font-weight: 900; }
     .pl-feedback-status-ok { color: #0f7b63; }
     .pl-feedback-status-fail { color: #d1495b; }
+    .pl-feedback-status-unknown { color: #8a9590; }
     .pl-tooltip { position: fixed; max-width: 280px; background: #14211d; color: #fff; padding: 8px 10px; border-radius: 6px; font-size: 12px; line-height: 1.4; pointer-events: none; z-index: 2147483002; box-shadow: 0 12px 30px rgba(20, 33, 29, 0.32); white-space: pre-wrap; word-break: break-word; }
     .pl-comment { position: fixed; z-index: 2147483001; width: min(320px, calc(100vw - 24px)); display: grid; gap: 10px; padding: 14px; background: #fff; border: 1px solid #d9e1dd; border-radius: 8px; box-shadow: 0 22px 70px rgba(20, 33, 29, 0.24); }
     .pl-comment label { display: grid; gap: 6px; color: #65716d; font-size: 12px; font-weight: 800; }


### PR DESCRIPTION
Refs #54（close はしません — 項目 6・7 が残るため）

## 対応した項目（issue の 1〜5）
1. **id 衝突**: `pl_${Date.now()}` → `pl_<ts>_<random8>`（`crypto.randomUUID` 利用、非 secure context は `Math.random` フォールバック）。receiver の screenshot ファイル名にも random suffix 追加
2. **destroy() の後始末**: `pl-feedback-active` class（crosshair）と注入 `<style>` を除去
3. **Slack direct の false success**: opaque response を `ok: null` /「?」表示（unknown）に変更。あわせて escape → truncate の順に修正（エスケープ膨張による 3000 字超過防止。comment と element text の 2 箇所）
4. **Safari 15**: `requestSubmit` 不在時は submit ボタン click にフォールバック（submit イベント経路は同一）
5. **init() 二重呼び / head から init**: body 不在なら DOMContentLoaded 後に再試行。mode ON のままの再 init は mode 状態をリセットしてから再描画

## 残し（issue に追記コメント予定）
- 項目 6（screenshots / feedback の無限蓄積 → DELETE endpoint）は路線 2 の領域
- 項目 7（テストの穴）のうち 413 は PR #67 でテスト追加済み

## 検証
- `npm run check` 全パス（44 件）
- headless Chrome 専用スモーク 10 項目全パス（連続キャプチャの id 一意性 / 再 init の状態リセットと再キャプチャ / destroy の class・style・root 除去 / **head から init するテストページ**でのマウント成功）
- 既存 widget スモーク 14 項目も全パス

⚠️ 他の widget 系 PR と `dist/patchloop-widget.js` が衝突します（merge 後に rebase + build で追従します）