### PR TITLE
Screenshot CSS 処理のエッジケース対応（vw regex / ネスト @media / adopted・disabled sheets / body 反映）

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -217,6 +217,76 @@ function textFor(element) {
 
 return { cssEscape, selectorFor, textFor };
 })();
+// --- widget/src/snapshot-css.js ---
+const __pl_widget_src_snapshot_css = (() => {
+// CSS processing for the SVG snapshot. Media conditions are injected as a
+// `mediaMatches(mediaText) => boolean` callback (window.matchMedia in the
+// browser) so node:test can exercise the flattening with plain objects.
+
+// Viewport units re-resolve against the rendered size just like media
+// queries do, so freeze them to the captured viewport in pixels.
+//
+// The lookbehind keeps the replacement to declaration values: a match is
+// rejected when it is glued to a preceding word/url character, which is what
+// base64 data URIs (`...A9vw/`, `+5vh=`), escaped selectors (`.h-\[100vh\]`),
+// and custom property names (`--col-50vw`) all look like. Real CSS values are
+// preceded by a space, `(`, `,` or `:`; even calc() requires whitespace
+// around `+`/`-`, so a glued sign cannot be a real value either.
+const VIEWPORT_UNIT_RE = /(?<![\w.%#/\\[+-])(-?\d*\.?\d+)(?:[dsl])?v(w|h|min|max)\b/g;
+
+function freezeViewportUnits(cssText, width, height) {
+  return cssText.replace(VIEWPORT_UNIT_RE, (match, number, axis) => {
+    const value = Number(number);
+    if (!Number.isFinite(value)) return match;
+    const base = axis === "w"
+      ? width
+      : axis === "h"
+        ? height
+        : axis === "min" ? Math.min(width, height) : Math.max(width, height);
+    return `${(value * base) / 100}px`;
+  });
+}
+
+function flattenRulesForSnapshot(rules, mediaMatches) {
+  return Array.from(rules || [])
+    .map((rule) => {
+      if (rule.styleSheet) {
+        // @import: inline the imported sheet, honoring its media list.
+        const media = rule.media && rule.media.mediaText;
+        if (media && !mediaMatches(media)) return "";
+        try {
+          return flattenRulesForSnapshot(rule.styleSheet.cssRules, mediaMatches);
+        } catch (_) {
+          return "";
+        }
+      }
+      if (rule.media) {
+        return mediaMatches(rule.media.mediaText)
+          ? flattenRulesForSnapshot(rule.cssRules, mediaMatches)
+          : "";
+      }
+      if (rule.cssRules && rule.cssRules.length) {
+        // Grouping rules (@supports, @layer, @container, @keyframes, …):
+        // keep the wrapper but flatten the children, so an @media nested
+        // inside resolves at capture time instead of re-evaluating against
+        // the SVG's rendered size. @container still re-evaluates against
+        // the rendered container (issue #51 leftover) — resolving it would
+        // need per-element layout queries.
+        const inner = flattenRulesForSnapshot(rule.cssRules, mediaMatches);
+        if (!inner) return "";
+        const cssText = rule.cssText || "";
+        const braceIndex = cssText.indexOf("{");
+        if (braceIndex === -1) return cssText;
+        return `${cssText.slice(0, braceIndex).trim()} {\n${inner}\n}`;
+      }
+      return rule.cssText;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+return { freezeViewportUnits, flattenRulesForSnapshot };
+})();
 // --- shared/format.js ---
 const __pl_shared_format = (() => {
 // Formatting helpers shared by the widget (bundled into dist) and the
@@ -281,6 +351,7 @@ return { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackC
 const { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarget, rectFromStoredArea, round, numberOrNull } = __pl_widget_src_geometry;
 const { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } = __pl_widget_src_anchoring;
 const { selectorFor, textFor } = __pl_widget_src_selector;
+const { freezeViewportUnits, flattenRulesForSnapshot } = __pl_widget_src_snapshot_css;
 const { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } = __pl_shared_format;
 
 const DEFAULTS = {
@@ -843,9 +914,19 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
   bodyClone.querySelectorAll(".pl-target-highlight").forEach((node) => node.classList.remove("pl-target-highlight"));
 
   const bodyStyle = window.getComputedStyle(document.body);
-  const background = bodyStyle.backgroundColor || "#ffffff";
+  // A transparent body paints the html (or default white) background; the
+  // snapshot must do the same instead of losing the page background.
+  const background = visibleBackground(bodyStyle.backgroundColor)
+    || visibleBackground(window.getComputedStyle(document.documentElement).backgroundColor)
+    || "#ffffff";
   const color = bodyStyle.color || "#14211d";
   const font = bodyStyle.font || bodyStyle.fontFamily || "system-ui, sans-serif";
+  const htmlClassAttr = snapshotClassAttr(document.documentElement);
+  const bodyClassAttr = snapshotClassAttr(document.body);
+  // The <body> tag is regenerated, so its inline style must be carried
+  // over; the snapshot's own layout overrides come after and win.
+  const bodyInlineStyle = String(document.body.getAttribute("style") || "").trim();
+  const bodyStylePrefix = bodyInlineStyle ? bodyInlineStyle.replace(/;?$/, ";") : "";
   const styles = `${freezeViewportUnits(collectReadableStyles(), width, height)}\n* { box-sizing: border-box; }\n`;
   const overlayMarkup = renderScreenshotOverlay(overlay);
   const bodyMarkup = serializeAsXhtml(bodyClone);
@@ -854,11 +935,11 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
 <rect width="100%" height="100%" fill="${escapeXml(background)}"/>
 <foreignObject x="0" y="0" width="${width}" height="${height}">
-  <html xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px;height:${height}px;overflow:hidden;background:${escapeHtml(background)};">
+  <html xmlns="http://www.w3.org/1999/xhtml"${htmlClassAttr} style="width:${width}px;height:${height}px;overflow:hidden;background:${escapeHtml(background)};">
     <head>
       <style><![CDATA[${styles.replaceAll("]]>", "]]]]><![CDATA[>")}]]></style>
     </head>
-    <body style="margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
+    <body${bodyClassAttr} style="${escapeHtml(bodyStylePrefix)}margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
       ${bodyMarkup}
     </body>
   </html>
@@ -866,6 +947,21 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
 <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" fill="none" stroke="#d9e1dd"/>
 ${overlayMarkup}
 </svg>`;
+}
+
+function visibleBackground(value) {
+  if (!value || value === "transparent" || value === "rgba(0, 0, 0, 0)") return "";
+  return value;
+}
+
+function snapshotClassAttr(element) {
+  // The widget's own mode class (crosshair cursor) is capture-state, not
+  // page state, and must not leak into the snapshot.
+  const value = String(element.getAttribute("class") || "")
+    .split(/\s+/)
+    .filter((token) => token && token !== "pl-feedback-active")
+    .join(" ");
+  return value ? ` class="${escapeHtml(value)}"` : "";
 }
 
 // The SVG is parsed as XML, so the clone must be serialized as XHTML:
@@ -894,56 +990,20 @@ function serializeAsXhtml(root) {
 // layout at any display size.
 function collectReadableStyles() {
   const chunks = [];
-  Array.from(document.styleSheets).forEach((sheet) => {
+  const mediaMatches = (mediaText) => window.matchMedia(mediaText).matches;
+  const sheets = [...Array.from(document.styleSheets), ...Array.from(document.adoptedStyleSheets || [])];
+  sheets.forEach((sheet) => {
     try {
       if (sheet.ownerNode?.dataset?.patchloopStyle) return;
-      if (sheet.media && sheet.media.mediaText && !window.matchMedia(sheet.media.mediaText).matches) return;
-      const flattened = flattenRulesForSnapshot(sheet.cssRules);
+      if (sheet.disabled) return;
+      if (sheet.media && sheet.media.mediaText && !mediaMatches(sheet.media.mediaText)) return;
+      const flattened = flattenRulesForSnapshot(sheet.cssRules, mediaMatches);
       if (flattened) chunks.push(flattened);
     } catch (_) {
       // Cross-origin stylesheets cannot be read. The snapshot still includes DOM and overlay context.
     }
   });
   return chunks.join("\n");
-}
-
-// Viewport units re-resolve against the rendered size just like media
-// queries do, so freeze them to the captured viewport in pixels.
-function freezeViewportUnits(cssText, width, height) {
-  return cssText.replace(/(-?\d*\.?\d+)(?:[dsl])?v(w|h|min|max)\b/g, (match, number, axis) => {
-    const value = Number(number);
-    if (!Number.isFinite(value)) return match;
-    const base = axis === "w"
-      ? width
-      : axis === "h"
-        ? height
-        : axis === "min" ? Math.min(width, height) : Math.max(width, height);
-    return `${(value * base) / 100}px`;
-  });
-}
-
-function flattenRulesForSnapshot(rules) {
-  return Array.from(rules || [])
-    .map((rule) => {
-      if (rule.styleSheet) {
-        // @import: inline the imported sheet, honoring its media list.
-        const media = rule.media && rule.media.mediaText;
-        if (media && !window.matchMedia(media).matches) return "";
-        try {
-          return flattenRulesForSnapshot(rule.styleSheet.cssRules);
-        } catch (_) {
-          return "";
-        }
-      }
-      if (rule.media) {
-        return window.matchMedia(rule.media.mediaText).matches
-          ? flattenRulesForSnapshot(rule.cssRules)
-          : "";
-      }
-      return rule.cssText;
-    })
-    .filter(Boolean)
-    .join("\n");
 }
 
 // Overlay coordinates must be viewport-relative at capture time, so derive

--- a/test/widget-snapshot-css.test.js
+++ b/test/widget-snapshot-css.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { freezeViewportUnits, flattenRulesForSnapshot } = require("../widget/src/snapshot-css.js");
+
+test("freezeViewportUnits resolves viewport units against the captured size", () => {
+  const frozen = (css) => freezeViewportUnits(css, 1000, 500);
+  assert.equal(frozen("width: 100vw;"), "width: 1000px;");
+  assert.equal(frozen("height: 50vh;"), "height: 250px;");
+  assert.equal(frozen("font-size: 10vmin;"), "font-size: 50px;");
+  assert.equal(frozen("font-size: 10vmax;"), "font-size: 100px;");
+  assert.equal(frozen("width: .5vw;"), "width: 5px;");
+  assert.equal(frozen("margin: -50vw;"), "margin: -500px;");
+  assert.equal(frozen("margin:-50vw;"), "margin:-500px;");
+  assert.equal(frozen("width: 12.5vw;"), "width: 125px;");
+  assert.equal(frozen("width: 100dvw; height: 100svh;"), "width: 1000px; height: 500px;");
+  assert.equal(frozen("width: calc(100vw - 50px);"), "width: calc(1000px - 50px);");
+});
+
+test("freezeViewportUnits leaves lookalikes outside declaration values alone", () => {
+  const frozen = (css) => freezeViewportUnits(css, 1000, 500);
+  // base64 in a data URI
+  const dataUri = 'background: url("data:image/png;base64,iVBORw0A9vw/9vwX+5vh=");';
+  assert.equal(frozen(dataUri), dataUri);
+  // escaped utility-class selector
+  const escaped = ".h-\\[100vh\\] { color: red; }";
+  assert.equal(frozen(escaped), escaped);
+  // custom property *name* keeps its name (the value is still resolved)
+  assert.equal(frozen("--col-50vw: 10px;"), "--col-50vw: 10px;");
+  assert.equal(frozen("--width: 50vw;"), "--width: 500px;");
+});
+
+function styleRule(cssText) {
+  return { cssText };
+}
+
+function mediaRule(mediaText, children) {
+  return { media: { mediaText }, cssRules: children };
+}
+
+function groupRule(header, children) {
+  return { cssRules: children, cssText: `${header} {\n  ...\n}` };
+}
+
+const matchesNarrow = (mediaText) => mediaText.includes("max-width");
+
+test("flattenRulesForSnapshot inlines matching media and drops the rest", () => {
+  const rules = [
+    styleRule("body { color: red; }"),
+    mediaRule("(max-width: 600px)", [styleRule(".narrow { display: none; }")]),
+    mediaRule("(min-width: 1200px)", [styleRule(".wide { display: none; }")])
+  ];
+  assert.equal(
+    flattenRulesForSnapshot(rules, matchesNarrow),
+    "body { color: red; }\n.narrow { display: none; }"
+  );
+});
+
+test("flattenRulesForSnapshot keeps grouping wrappers but resolves nested media", () => {
+  const supports = groupRule("@supports (display: grid)", [
+    styleRule(".grid { display: grid; }"),
+    mediaRule("(max-width: 600px)", [styleRule(".grid { gap: 4px; }")]),
+    mediaRule("(min-width: 1200px)", [styleRule(".grid { gap: 24px; }")])
+  ]);
+  assert.equal(
+    flattenRulesForSnapshot([supports], matchesNarrow),
+    "@supports (display: grid) {\n.grid { display: grid; }\n.grid { gap: 4px; }\n}"
+  );
+
+  const layer = groupRule("@layer components", [mediaRule("(min-width: 1200px)", [styleRule(".x{}")])]);
+  assert.equal(flattenRulesForSnapshot([layer], matchesNarrow), "");
+});
+
+test("flattenRulesForSnapshot preserves @keyframes wholesale", () => {
+  const keyframes = groupRule("@keyframes spin", [
+    styleRule("0% { transform: rotate(0deg); }"),
+    styleRule("100% { transform: rotate(360deg); }")
+  ]);
+  assert.equal(
+    flattenRulesForSnapshot([keyframes], matchesNarrow),
+    "@keyframes spin {\n0% { transform: rotate(0deg); }\n100% { transform: rotate(360deg); }\n}"
+  );
+});
+
+test("flattenRulesForSnapshot inlines @import sheets, honoring their media list", () => {
+  const importedMatch = {
+    media: { mediaText: "(max-width: 600px)" },
+    styleSheet: { cssRules: [styleRule(".imported { color: blue; }")] }
+  };
+  const importedSkip = {
+    media: { mediaText: "(min-width: 1200px)" },
+    styleSheet: { cssRules: [styleRule(".skipped {}")] }
+  };
+  const importedUnreadable = {
+    styleSheet: {
+      get cssRules() {
+        throw new Error("cross-origin");
+      }
+    }
+  };
+  assert.equal(
+    flattenRulesForSnapshot([importedMatch, importedSkip, importedUnreadable], matchesNarrow),
+    ".imported { color: blue; }"
+  );
+});

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -1,6 +1,7 @@
 import { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarget, rectFromStoredArea, round, numberOrNull } from "./geometry.js";
 import { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } from "./anchoring.js";
 import { selectorFor, textFor } from "./selector.js";
+import { freezeViewportUnits, flattenRulesForSnapshot } from "./snapshot-css.js";
 import { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } from "../../shared/format.js";
 
 const DEFAULTS = {
@@ -563,9 +564,19 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
   bodyClone.querySelectorAll(".pl-target-highlight").forEach((node) => node.classList.remove("pl-target-highlight"));
 
   const bodyStyle = window.getComputedStyle(document.body);
-  const background = bodyStyle.backgroundColor || "#ffffff";
+  // A transparent body paints the html (or default white) background; the
+  // snapshot must do the same instead of losing the page background.
+  const background = visibleBackground(bodyStyle.backgroundColor)
+    || visibleBackground(window.getComputedStyle(document.documentElement).backgroundColor)
+    || "#ffffff";
   const color = bodyStyle.color || "#14211d";
   const font = bodyStyle.font || bodyStyle.fontFamily || "system-ui, sans-serif";
+  const htmlClassAttr = snapshotClassAttr(document.documentElement);
+  const bodyClassAttr = snapshotClassAttr(document.body);
+  // The <body> tag is regenerated, so its inline style must be carried
+  // over; the snapshot's own layout overrides come after and win.
+  const bodyInlineStyle = String(document.body.getAttribute("style") || "").trim();
+  const bodyStylePrefix = bodyInlineStyle ? bodyInlineStyle.replace(/;?$/, ";") : "";
   const styles = `${freezeViewportUnits(collectReadableStyles(), width, height)}\n* { box-sizing: border-box; }\n`;
   const overlayMarkup = renderScreenshotOverlay(overlay);
   const bodyMarkup = serializeAsXhtml(bodyClone);
@@ -574,11 +585,11 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
 <rect width="100%" height="100%" fill="${escapeXml(background)}"/>
 <foreignObject x="0" y="0" width="${width}" height="${height}">
-  <html xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px;height:${height}px;overflow:hidden;background:${escapeHtml(background)};">
+  <html xmlns="http://www.w3.org/1999/xhtml"${htmlClassAttr} style="width:${width}px;height:${height}px;overflow:hidden;background:${escapeHtml(background)};">
     <head>
       <style><![CDATA[${styles.replaceAll("]]>", "]]]]><![CDATA[>")}]]></style>
     </head>
-    <body style="margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
+    <body${bodyClassAttr} style="${escapeHtml(bodyStylePrefix)}margin:0;width:${documentWidth}px;min-height:${documentHeight}px;background:${escapeHtml(background)};color:${escapeHtml(color)};font:${escapeHtml(font)};transform:translate(${-Math.round(scrollX)}px, ${-Math.round(scrollY)}px);transform-origin:top left;">
       ${bodyMarkup}
     </body>
   </html>
@@ -586,6 +597,21 @@ function buildScreenshotSvg({ width, height, documentWidth, documentHeight, scro
 <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" fill="none" stroke="#d9e1dd"/>
 ${overlayMarkup}
 </svg>`;
+}
+
+function visibleBackground(value) {
+  if (!value || value === "transparent" || value === "rgba(0, 0, 0, 0)") return "";
+  return value;
+}
+
+function snapshotClassAttr(element) {
+  // The widget's own mode class (crosshair cursor) is capture-state, not
+  // page state, and must not leak into the snapshot.
+  const value = String(element.getAttribute("class") || "")
+    .split(/\s+/)
+    .filter((token) => token && token !== "pl-feedback-active")
+    .join(" ");
+  return value ? ` class="${escapeHtml(value)}"` : "";
 }
 
 // The SVG is parsed as XML, so the clone must be serialized as XHTML:
@@ -614,56 +640,20 @@ function serializeAsXhtml(root) {
 // layout at any display size.
 function collectReadableStyles() {
   const chunks = [];
-  Array.from(document.styleSheets).forEach((sheet) => {
+  const mediaMatches = (mediaText) => window.matchMedia(mediaText).matches;
+  const sheets = [...Array.from(document.styleSheets), ...Array.from(document.adoptedStyleSheets || [])];
+  sheets.forEach((sheet) => {
     try {
       if (sheet.ownerNode?.dataset?.patchloopStyle) return;
-      if (sheet.media && sheet.media.mediaText && !window.matchMedia(sheet.media.mediaText).matches) return;
-      const flattened = flattenRulesForSnapshot(sheet.cssRules);
+      if (sheet.disabled) return;
+      if (sheet.media && sheet.media.mediaText && !mediaMatches(sheet.media.mediaText)) return;
+      const flattened = flattenRulesForSnapshot(sheet.cssRules, mediaMatches);
       if (flattened) chunks.push(flattened);
     } catch (_) {
       // Cross-origin stylesheets cannot be read. The snapshot still includes DOM and overlay context.
     }
   });
   return chunks.join("\n");
-}
-
-// Viewport units re-resolve against the rendered size just like media
-// queries do, so freeze them to the captured viewport in pixels.
-function freezeViewportUnits(cssText, width, height) {
-  return cssText.replace(/(-?\d*\.?\d+)(?:[dsl])?v(w|h|min|max)\b/g, (match, number, axis) => {
-    const value = Number(number);
-    if (!Number.isFinite(value)) return match;
-    const base = axis === "w"
-      ? width
-      : axis === "h"
-        ? height
-        : axis === "min" ? Math.min(width, height) : Math.max(width, height);
-    return `${(value * base) / 100}px`;
-  });
-}
-
-function flattenRulesForSnapshot(rules) {
-  return Array.from(rules || [])
-    .map((rule) => {
-      if (rule.styleSheet) {
-        // @import: inline the imported sheet, honoring its media list.
-        const media = rule.media && rule.media.mediaText;
-        if (media && !window.matchMedia(media).matches) return "";
-        try {
-          return flattenRulesForSnapshot(rule.styleSheet.cssRules);
-        } catch (_) {
-          return "";
-        }
-      }
-      if (rule.media) {
-        return window.matchMedia(rule.media.mediaText).matches
-          ? flattenRulesForSnapshot(rule.cssRules)
-          : "";
-      }
-      return rule.cssText;
-    })
-    .filter(Boolean)
-    .join("\n");
 }
 
 // Overlay coordinates must be viewport-relative at capture time, so derive

--- a/widget/src/snapshot-css.js
+++ b/widget/src/snapshot-css.js
@@ -1,0 +1,65 @@
+// CSS processing for the SVG snapshot. Media conditions are injected as a
+// `mediaMatches(mediaText) => boolean` callback (window.matchMedia in the
+// browser) so node:test can exercise the flattening with plain objects.
+
+// Viewport units re-resolve against the rendered size just like media
+// queries do, so freeze them to the captured viewport in pixels.
+//
+// The lookbehind keeps the replacement to declaration values: a match is
+// rejected when it is glued to a preceding word/url character, which is what
+// base64 data URIs (`...A9vw/`, `+5vh=`), escaped selectors (`.h-\[100vh\]`),
+// and custom property names (`--col-50vw`) all look like. Real CSS values are
+// preceded by a space, `(`, `,` or `:`; even calc() requires whitespace
+// around `+`/`-`, so a glued sign cannot be a real value either.
+const VIEWPORT_UNIT_RE = /(?<![\w.%#/\\[+-])(-?\d*\.?\d+)(?:[dsl])?v(w|h|min|max)\b/g;
+
+export function freezeViewportUnits(cssText, width, height) {
+  return cssText.replace(VIEWPORT_UNIT_RE, (match, number, axis) => {
+    const value = Number(number);
+    if (!Number.isFinite(value)) return match;
+    const base = axis === "w"
+      ? width
+      : axis === "h"
+        ? height
+        : axis === "min" ? Math.min(width, height) : Math.max(width, height);
+    return `${(value * base) / 100}px`;
+  });
+}
+
+export function flattenRulesForSnapshot(rules, mediaMatches) {
+  return Array.from(rules || [])
+    .map((rule) => {
+      if (rule.styleSheet) {
+        // @import: inline the imported sheet, honoring its media list.
+        const media = rule.media && rule.media.mediaText;
+        if (media && !mediaMatches(media)) return "";
+        try {
+          return flattenRulesForSnapshot(rule.styleSheet.cssRules, mediaMatches);
+        } catch (_) {
+          return "";
+        }
+      }
+      if (rule.media) {
+        return mediaMatches(rule.media.mediaText)
+          ? flattenRulesForSnapshot(rule.cssRules, mediaMatches)
+          : "";
+      }
+      if (rule.cssRules && rule.cssRules.length) {
+        // Grouping rules (@supports, @layer, @container, @keyframes, …):
+        // keep the wrapper but flatten the children, so an @media nested
+        // inside resolves at capture time instead of re-evaluating against
+        // the SVG's rendered size. @container still re-evaluates against
+        // the rendered container (issue #51 leftover) — resolving it would
+        // need per-element layout queries.
+        const inner = flattenRulesForSnapshot(rule.cssRules, mediaMatches);
+        if (!inner) return "";
+        const cssText = rule.cssText || "";
+        const braceIndex = cssText.indexOf("{");
+        if (braceIndex === -1) return cssText;
+        return `${cssText.slice(0, braceIndex).trim()} {\n${inner}\n}`;
+      }
+      return rule.cssText;
+    })
+    .filter(Boolean)
+    .join("\n");
+}


### PR DESCRIPTION
Closes #51

## 対応内容（issue の 1 / 2 / 4 / 5）
1. **freezeViewportUnits の誤変換**: lookbehind で「直前が単語系文字（`[\w.%#/\\[+-]`）の数値」を除外。base64 data URI（`A9vw/`・`+5vh=`）、エスケープ済みセレクタ（`.h-\[100vh\]`）、custom property 名（`--col-50vw`）を変換しなくなった。calc は `+`/`-` の前後に空白必須なので glued な符号は実値になり得ない、という根拠で安全側に倒している
2. **ネストした @media**: `flattenRulesForSnapshot` が grouping rule（@supports / @layer / @container / @keyframes）全般に再帰し、**ラッパーは保持しつつ内側の @media を capture 時に解決**。@keyframes は丸ごと保持
3. **disabled / adopted stylesheets**: `sheet.disabled` を除外、`document.adoptedStyleSheets` を取り込み
4. **body / html の反映**: 再生成する `<html>` / `<body>` にページの class 属性と body の inline style を引き継ぎ（widget 自身の `pl-feedback-active` は除去）。透明 body は html の背景色にフォールバック

2 関数は `widget/src/snapshot-css.js` に切り出し（matchMedia は注入）、node:test 6 件で固定。

## 対応しない残課題（→ #54 に追記）
- **@container**: 表示サイズで再評価される（解決には要素単位の layout query が必要）。ラッパー保持により内側の @media 解決までは効く
- **shadow DOM / iframe**: snapshot に写らない（従来どおり）

## 検証
- `npm run check` 全パス（テスト 50 件 = 44 + snapshot-css 6）
- エッジケースを詰め込んだ専用ページで headless Chrome スモーク **18 項目全パス**（SVG が image として描画可能 / ネスト @media の解決と非マッチ除去 / @supports・@keyframes 保持 / data URI 不変 / vw 凍結 / disabled 除外・adopted 取り込み / body・html class と inline style 反映 / html 背景フォールバック / widget の mode class 非混入）
- 既存 widget スモーク 14 項目も全パス

⚠️ 他の widget 系 PR と `dist/patchloop-widget.js` が衝突します（merge 後に rebase + build で追従します）