### PR TITLE
payload に schemaVersion を持たせる

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -374,6 +374,10 @@ const DEFAULTS = {
 const EXPORT_KIND = "patchloop-feedback-bundle";
 const EXPORT_VERSION = 1;
 const FEEDBACK_STORAGE_VERSION = 1;
+// Version of the feedback payload schema itself (distinct from the storage
+// envelope and export bundle versions). Bump when the payload shape changes
+// so the receiver can branch on it as the schema grows for team use.
+const PAYLOAD_SCHEMA_VERSION = 1;
 
 const state = {
   options: { ...DEFAULTS },
@@ -815,6 +819,7 @@ async function submitComment(event) {
 
 function buildPayload(comment, reviewer, target) {
   return {
+    schemaVersion: PAYLOAD_SCHEMA_VERSION,
     id: generateFeedbackId(),
     projectId: state.options.projectId,
     demoId: state.options.demoId,

--- a/server/receive.js
+++ b/server/receive.js
@@ -36,6 +36,9 @@ const GITHUB_CONFIGURED = Boolean(GITHUB_TOKEN && GITHUB_REPO);
 const IMPORT_BUNDLE_KIND = "patchloop-feedback-bundle";
 const IMPORT_BUNDLE_VERSION = 1;
 const FEEDBACK_STATUSES = ["new", "accepted", "fixed", "ignored"];
+// Default applied to payloads received before the widget sent schemaVersion,
+// so every stored item carries a version going forward.
+const DEFAULT_SCHEMA_VERSION = 1;
 
 let feedback = loadFeedback();
 
@@ -184,7 +187,12 @@ function handlePostFeedback(req, res) {
       return;
     }
 
-    const stored = { receivedAt: new Date().toISOString(), ...payload, screenshot };
+    const stored = {
+      receivedAt: new Date().toISOString(),
+      schemaVersion: DEFAULT_SCHEMA_VERSION,
+      ...payload,
+      screenshot
+    };
     stored.integrations = {
       ...(stored.integrations || {}),
       slack: await deliverToSlack(stored)
@@ -218,6 +226,7 @@ function handlePostImport(req, res) {
 
     const now = new Date().toISOString();
     const stored = {
+      schemaVersion: DEFAULT_SCHEMA_VERSION,
       ...imported,
       receivedAt: now,
       importedAt: now,
@@ -474,6 +483,9 @@ function validateFeedbackPayload(payload) {
   requirePlainObject(payload.target, "feedback.target");
   requirePlainObject(payload.environment, "feedback.environment");
 
+  if (payload.schemaVersion != null && !Number.isInteger(payload.schemaVersion)) {
+    throw httpError("feedback.schemaVersion must be an integer", 400);
+  }
   if (payload.projectId != null) requireString(payload.projectId, "feedback.projectId");
   if (payload.demoId != null) requireString(payload.demoId, "feedback.demoId");
   if (payload.createdAt != null) requireString(payload.createdAt, "feedback.createdAt");

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -385,6 +385,32 @@ test("upload-only Slack config reports skipped, not failed, without a screenshot
   assert.equal(stored[0].integrations.slack.status, "skipped");
 });
 
+test("schemaVersion is stored, defaulted for legacy payloads, and validated", async (t) => {
+  const receiver = await startReceiver(t);
+
+  // explicit version is kept
+  const versioned = feedbackPayload("pl_schema_1");
+  versioned.schemaVersion = 1;
+  await postJson(`${receiver.baseUrl}/feedback`, versioned);
+
+  // legacy payload without a version gets the default
+  const legacy = feedbackPayload("pl_schema_legacy");
+  delete legacy.schemaVersion;
+  await postJson(`${receiver.baseUrl}/feedback`, legacy);
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  const byId = Object.fromEntries(stored.map((item) => [item.id, item]));
+  assert.equal(byId.pl_schema_1.schemaVersion, 1);
+  assert.equal(byId.pl_schema_legacy.schemaVersion, 1);
+
+  // a non-integer version is rejected
+  const bad = feedbackPayload("pl_schema_bad");
+  bad.schemaVersion = "v1";
+  const rejected = await postJson(`${receiver.baseUrl}/feedback`, bad);
+  assert.equal(rejected.status, 400);
+  assert.match(rejected.body.error, /schemaVersion must be an integer/);
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();
@@ -520,6 +546,7 @@ async function readStoredFeedback(storePath) {
 
 function feedbackPayload(id) {
   return {
+    schemaVersion: 1,
     id,
     projectId: "patchloop",
     demoId: "receiver-test",

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -24,6 +24,10 @@ const DEFAULTS = {
 const EXPORT_KIND = "patchloop-feedback-bundle";
 const EXPORT_VERSION = 1;
 const FEEDBACK_STORAGE_VERSION = 1;
+// Version of the feedback payload schema itself (distinct from the storage
+// envelope and export bundle versions). Bump when the payload shape changes
+// so the receiver can branch on it as the schema grows for team use.
+const PAYLOAD_SCHEMA_VERSION = 1;
 
 const state = {
   options: { ...DEFAULTS },
@@ -465,6 +469,7 @@ async function submitComment(event) {
 
 function buildPayload(comment, reviewer, target) {
   return {
+    schemaVersion: PAYLOAD_SCHEMA_VERSION,
     id: generateFeedbackId(),
     projectId: state.options.projectId,
     demoId: state.options.demoId,


### PR DESCRIPTION
Closes #71

路線 2（チーム運用土台）の 1 本目。

## 変更内容
- widget: `PAYLOAD_SCHEMA_VERSION = 1` を定義し、`buildPayload` の先頭に `schemaVersion` を付与（storage envelope / export bundle の版とは別物）
- receiver: `validateFeedbackPayload` で `schemaVersion` が整数であることを検証（任意）。POST / import どちらの経路でも、版を持たない旧 payload には `DEFAULT_SCHEMA_VERSION = 1` を補完して保存
- テストヘルパー `feedbackPayload` も実際の widget 出力に合わせて `schemaVersion: 1` を持たせた

## 検証
- `npm run check` 全パス（テスト 55 件。明示版の保持 / 旧 payload への既定値補完 / 非整数の 400 拒否を追加）
- headless Chrome 回帰 14 項目パス + 実機 payload に `schemaVersion=1` が乗ることを確認