### PR TITLE
マルチプロジェクト: inbox の project/demo フィルタと feedback.json のクエリ絞り込み

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -88,7 +88,7 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === "GET" && pathname === "/feedback.json") {
-    respondJson(res, 200, feedback);
+    handleGetFeedbackJson(req, res);
     return;
   }
 
@@ -523,6 +523,34 @@ function requireNonEmptyString(value, label) {
 function handleGetInbox(req, res) {
   res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
   res.end(renderInbox(feedback));
+}
+
+// GET /feedback.json supports ?projectId=&demoId=&status= to narrow the
+// export, so a shared receiver can hand each project just its own feedback.
+function handleGetFeedbackJson(req, res) {
+  let params;
+  try {
+    params = new URL(req.url, "http://localhost").searchParams;
+  } catch (_) {
+    respondJson(res, 400, { ok: false, error: "Invalid query" });
+    return;
+  }
+
+  const projectId = params.get("projectId");
+  const demoId = params.get("demoId");
+  const status = params.get("status");
+
+  if (status != null && !FEEDBACK_STATUSES.includes(status)) {
+    respondJson(res, 400, { ok: false, error: `status must be one of: ${FEEDBACK_STATUSES.join(", ")}` });
+    return;
+  }
+
+  const filtered = feedback.filter((item) =>
+    (projectId == null || (item.projectId || "") === projectId)
+    && (demoId == null || (item.demoId || "") === demoId)
+    && (status == null || feedbackStatusOf(item) === status));
+
+  respondJson(res, 200, filtered);
 }
 
 function handleGetWidgetScript(req, res) {
@@ -1140,6 +1168,8 @@ function renderInbox(items) {
     const createdAt = escapeHtml(item.createdAt || "");
     const receivedAt = escapeHtml(item.receivedAt || "");
     const source = escapeHtml(item.source || "receiver");
+    const project = escapeHtml(item.projectId || "");
+    const demo = escapeHtml(item.demoId || "");
     const importedAt = escapeHtml(item.importedAt || "");
     const status = feedbackStatusOf(item);
     const slackStatus = escapeHtml((slack && slack.status) || "unknown");
@@ -1154,7 +1184,7 @@ function renderInbox(items) {
       ? `${env.viewport.width}×${env.viewport.height}`
       : "";
     return `
-      <article class="card" data-card data-status="${status}" data-kind="${kind}" data-reviewer="${reviewer}" data-source="${source}" data-slack="${slackStatus}" data-github="${githubStatus}" data-search="${searchText}">
+      <article class="card" data-card data-status="${status}" data-kind="${kind}" data-project="${project}" data-demo="${demo}" data-reviewer="${reviewer}" data-source="${source}" data-slack="${slackStatus}" data-github="${githubStatus}" data-search="${searchText}">
         <header>
           <span class="kind kind-${kind}">${kind}</span>
           <span class="reviewer">${reviewer || "(no name)"}</span>
@@ -1224,6 +1254,8 @@ function renderFilterPanel(items) {
     .concat(values.map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`))
     .join("");
   const unique = (mapper) => Array.from(new Set(items.map(mapper).filter(Boolean))).sort();
+  const projects = unique((item) => item.projectId || "");
+  const demos = unique((item) => item.demoId || "");
   const reviewers = unique((item) => item.reviewer || "");
   const sources = unique((item) => item.source || "receiver");
   const slackStatuses = unique((item) => (item.integrations && item.integrations.slack && item.integrations.slack.status) || "unknown");
@@ -1234,6 +1266,8 @@ function renderFilterPanel(items) {
     <input type="search" placeholder="検索（コメント / reviewer / selector / URL）" data-filter-text />
     <select data-filter-key="status">${optionList(FEEDBACK_STATUSES, "Status: all")}</select>
     <select data-filter-key="kind">${optionList(["point", "area"], "Kind: all")}</select>
+    <select data-filter-key="project">${optionList(projects, "Project: all")}</select>
+    <select data-filter-key="demo">${optionList(demos, "Demo: all")}</select>
     <select data-filter-key="reviewer">${optionList(reviewers, "Reviewer: all")}</select>
     <select data-filter-key="source">${optionList(sources, "Source: all")}</select>
     <select data-filter-key="slack">${optionList(slackStatuses, "Slack: all")}</select>

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -411,6 +411,50 @@ test("schemaVersion is stored, defaulted for legacy payloads, and validated", as
   assert.match(rejected.body.error, /schemaVersion must be an integer/);
 });
 
+test("GET /feedback.json filters by projectId, demoId, and status", async (t) => {
+  const receiver = await startReceiver(t);
+
+  const a = feedbackPayload("pl_filter_a");
+  a.projectId = "alpha";
+  a.demoId = "home";
+  const b = feedbackPayload("pl_filter_b");
+  b.projectId = "alpha";
+  b.demoId = "checkout";
+  const c = feedbackPayload("pl_filter_c");
+  c.projectId = "beta";
+  c.demoId = "home";
+  for (const p of [a, b, c]) await postJson(`${receiver.baseUrl}/feedback`, p);
+  await postJson(`${receiver.baseUrl}/feedback/pl_filter_b/status`, { status: "fixed" });
+
+  const ids = async (query) => {
+    const items = await fetch(`${receiver.baseUrl}/feedback.json${query}`).then((r) => r.json());
+    return items.map((item) => item.id).sort();
+  };
+
+  assert.deepEqual(await ids("?projectId=alpha"), ["pl_filter_a", "pl_filter_b"]);
+  assert.deepEqual(await ids("?demoId=home"), ["pl_filter_a", "pl_filter_c"]);
+  assert.deepEqual(await ids("?projectId=alpha&demoId=checkout"), ["pl_filter_b"]);
+  assert.deepEqual(await ids("?status=fixed"), ["pl_filter_b"]);
+  assert.deepEqual(await ids("?projectId=beta&demoId=checkout"), []);
+
+  const badStatus = await fetch(`${receiver.baseUrl}/feedback.json?status=wontfix`);
+  assert.equal(badStatus.status, 400);
+});
+
+test("inbox exposes project and demo filters with the data attributes", async (t) => {
+  const receiver = await startReceiver(t);
+  const item = feedbackPayload("pl_inbox_filter");
+  item.projectId = "alpha";
+  item.demoId = "home";
+  await postJson(`${receiver.baseUrl}/feedback`, item);
+
+  const html = await fetch(`${receiver.baseUrl}/`).then((r) => r.text());
+  assert.match(html, /data-filter-key="project"/);
+  assert.match(html, /data-filter-key="demo"/);
+  assert.match(html, /data-project="alpha"/);
+  assert.match(html, /data-demo="home"/);
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();


### PR DESCRIPTION
Closes #72

路線 2 の 2 本目。1 receiver に複数プロジェクト/デモが混在する前提に寄せる（EC2 共有 receiver の布石）。

## 変更内容
- inbox: フィルタパネルに **Project / Demo** の select を追加。各カードに `data-project` / `data-demo` を付与し、既存の汎用フィルタ script（`[data-filter-key]` × `card.dataset[key]`）がそのまま絞り込む（client JS の変更不要）
- `GET /feedback.json`: `?projectId=&demoId=&status=` で絞り込み可能に（pathname ルーティングは #50 で対応済み、`status` は不正値を 400）

スコープ外（中間レビュー課題 6 の残り）: GitHub repo の per-project 化はデプロイ領域なので別途

## 検証
- `npm run check` 全パス（テスト 57 件。feedback.json の projectId/demoId/status 絞り込みと不正 status の 400、inbox に project/demo フィルタと data 属性が出ることを追加）
- headless Chrome: `?projectId=alpha` が該当のみ返すこと、inbox の Project フィルタが 2 件→1 件に絞り「1 / 2 件」表示になることを確認