### PR TITLE
DELETE /feedback/:id とスクショ後始末（無限蓄積の解消）

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -70,6 +70,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  const deleteMatch = req.method === "DELETE" && /^\/feedback\/([^/]+)$/.exec(pathname);
+  if (deleteMatch) {
+    handleDeleteFeedback(req, res, decodeURIComponent(deleteMatch[1]));
+    return;
+  }
+
   const statusMatch = req.method === "POST" && /^\/feedback\/([^/]+)\/status$/.exec(pathname);
   if (statusMatch) {
     handlePostStatus(req, res, decodeURIComponent(statusMatch[1]));
@@ -124,7 +130,7 @@ server.listen(PORT, HOST, () => {
 
 function setCors(res) {
   res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 }
 
@@ -247,6 +253,37 @@ function handlePostImport(req, res) {
       source: "import"
     });
   });
+}
+
+async function handleDeleteFeedback(req, res, id) {
+  const index = feedback.findIndex((entry) => entry.id === id);
+  if (index === -1) {
+    respondJson(res, 404, { ok: false, error: `Unknown feedback id: ${id}` });
+    return;
+  }
+
+  const [removed] = feedback.splice(index, 1);
+  persist();
+  // Await the file removal so a 200 means the screenshot is gone too.
+  await deleteScreenshotFile(removed.screenshot);
+  console.log(`[PatchLoop receiver] deleted feedback id=${id}`);
+  respondJson(res, 200, { ok: true, id, count: feedback.length });
+}
+
+// Removes the stored screenshot for a deleted feedback. Confined to
+// SCREENSHOT_DIR so a tampered stored path cannot delete arbitrary files,
+// and missing files are ignored (the feedback is already gone).
+async function deleteScreenshotFile(screenshot) {
+  const storedPath = screenshot && screenshot.path;
+  if (!storedPath) return;
+  const resolved = path.resolve(storedPath);
+  const root = path.resolve(SCREENSHOT_DIR);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) return;
+  try {
+    await fs.promises.rm(resolved, { force: true });
+  } catch (error) {
+    console.warn(`[PatchLoop receiver] could not delete screenshot ${resolved}: ${error.message}`);
+  }
 }
 
 function handlePostStatus(req, res, id) {
@@ -1192,6 +1229,7 @@ function renderInbox(items) {
             <select data-status-select data-feedback-id="${escapeHtml(item.id || "")}">${statusOptions}</select>
           </label>
           <time>${receivedAt}</time>
+          <button type="button" class="delete-feedback" data-delete-feedback data-feedback-id="${escapeHtml(item.id || "")}" title="この feedback を削除">削除</button>
         </header>
         <p class="comment">${comment}</p>
         ${renderScreenshotPreview(screenshot)}

--- a/server/static/inbox.css
+++ b/server/static/inbox.css
@@ -26,6 +26,9 @@ h1 { margin: 0 0 8px; font-size: 20px; }
 .github-create { min-height: 24px; border: 1px solid #0f7b63; border-radius: 6px; background: #fff; color: #0f7b63; padding: 1px 8px; font: inherit; font-size: 11px; font-weight: 800; cursor: pointer; }
 .github-create:disabled { opacity: 0.6; cursor: default; }
 .github-error { color: #b83d4d; }
+.delete-feedback { min-height: 26px; border: 1px solid #d9e1dd; border-radius: 6px; background: #fff; color: #b83d4d; padding: 2px 8px; font: inherit; font-size: 11px; font-weight: 800; cursor: pointer; }
+.delete-feedback:hover { border-color: #b83d4d; background: #fdf0f2; }
+.delete-feedback:disabled { opacity: 0.6; cursor: default; }
 .kind { padding: 2px 8px; border-radius: 999px; font-weight: 800; color: #fff; font-size: 11px; text-transform: uppercase; }
 .kind-point { background: #0f7b63; }
 .kind-area { background: #d1495b; }

--- a/server/static/inbox.js
+++ b/server/static/inbox.js
@@ -106,4 +106,22 @@
       }
     });
   });
+
+  document.querySelectorAll("[data-delete-feedback]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      if (!window.confirm("この feedback を削除します。元に戻せません。よろしいですか？")) return;
+      button.disabled = true;
+      button.textContent = "削除中...";
+      try {
+        const response = await fetch("/feedback/" + encodeURIComponent(button.dataset.feedbackId), { method: "DELETE" });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.error || "Delete failed");
+        button.closest("[data-card]").remove();
+      } catch (error) {
+        button.disabled = false;
+        button.textContent = "削除";
+        window.alert(error.message);
+      }
+    });
+  });
 })();

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -455,6 +455,45 @@ test("inbox exposes project and demo filters with the data attributes", async (t
   assert.match(html, /data-demo="home"/);
 });
 
+test("DELETE /feedback/:id removes the item and its screenshot file", async (t) => {
+  const receiver = await startReceiver(t);
+  const payload = feedbackPayload("pl_delete_1");
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+  await postJson(`${receiver.baseUrl}/feedback`, feedbackPayload("pl_delete_keep"));
+
+  const before = await readStoredFeedback(receiver.storePath);
+  const screenshotPath = before.find((item) => item.id === "pl_delete_1").screenshot.path;
+  await fs.access(screenshotPath); // exists before delete
+
+  const response = await fetch(`${receiver.baseUrl}/feedback/pl_delete_1`, { method: "DELETE" });
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(body, { ok: true, id: "pl_delete_1", count: 1 });
+
+  const after = await readStoredFeedback(receiver.storePath);
+  assert.deepEqual(after.map((item) => item.id), ["pl_delete_keep"]);
+  await assert.rejects(fs.access(screenshotPath), /ENOENT/);
+});
+
+test("DELETE /feedback/:id returns 404 for an unknown id", async (t) => {
+  const receiver = await startReceiver(t);
+  await postJson(`${receiver.baseUrl}/feedback`, feedbackPayload("pl_delete_present"));
+
+  const response = await fetch(`${receiver.baseUrl}/feedback/pl_missing`, { method: "DELETE" });
+  assert.equal(response.status, 404);
+  assert.match((await response.json()).error, /Unknown feedback id/);
+
+  const stored = await readStoredFeedback(receiver.storePath);
+  assert.equal(stored.length, 1);
+});
+
+test("inbox renders a delete button per card", async (t) => {
+  const receiver = await startReceiver(t);
+  await postJson(`${receiver.baseUrl}/feedback`, feedbackPayload("pl_delete_ui"));
+  const html = await fetch(`${receiver.baseUrl}/`).then((r) => r.text());
+  assert.match(html, /data-delete-feedback data-feedback-id="pl_delete_ui"/);
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();


### PR DESCRIPTION
Closes #73 / #54 の項目 6 を一部解消

路線 2 の 3 本目。feedback を消す手段が無く store もスクショも無限に増えていた問題への対応。

## 変更内容
- `DELETE /feedback/:id`: store から除去 → `persist()` → 紐づくスクショファイル削除。削除は `SCREENSHOT_DIR` 配下に封じ込め（改竄された path で任意ファイルを消せない）、応答前に await するので **200 が返ったらファイルも消えている**契約。不在 id は 404
- CORS の許可メソッドに `DELETE` を追加
- inbox: 各カードに削除ボタン（`window.confirm` で確認 → DELETE → 成功でカードを DOM から除去、失敗は alert で復帰）

## 検証
- `npm run check` 全パス（テスト 60 件。削除でアイテム＋スクショファイルが消えること / 不在 id の 404 / inbox に削除ボタンが出ることを追加）
- headless Chrome: inbox の削除ボタンで confirm → カードが DOM から消え、`feedback.json` も該当のみ除去されることを確認