### PR TITLE
widget: 編集で送り済みコメントを未送信に戻す (#79 must fix)

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -788,8 +788,16 @@ async function submitComment(event) {
   if (state.editingId) {
     const target = state.feedback.find((item) => item.id === state.editingId);
     if (target) {
+      const changed = target.comment !== comment || target.reviewer !== reviewer;
       target.comment = comment;
       target.reviewer = reviewer;
+      // An edited comment that was already exported must re-enter the unsent
+      // batch, otherwise the correction never reaches the receiver.
+      if (changed && target.exported) {
+        delete target.exported;
+        delete target.exportedAt;
+        delete target.exportedFileName;
+      }
       saveReviewer(reviewer);
       persistFeedbackList();
       renderFeedbackList();

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -438,8 +438,16 @@ async function submitComment(event) {
   if (state.editingId) {
     const target = state.feedback.find((item) => item.id === state.editingId);
     if (target) {
+      const changed = target.comment !== comment || target.reviewer !== reviewer;
       target.comment = comment;
       target.reviewer = reviewer;
+      // An edited comment that was already exported must re-enter the unsent
+      // batch, otherwise the correction never reaches the receiver.
+      if (changed && target.exported) {
+        delete target.exported;
+        delete target.exportedAt;
+        delete target.exportedFileName;
+      }
       saveReviewer(reviewer);
       persistFeedbackList();
       renderFeedbackList();


### PR DESCRIPTION
## 概要

#79 の Codex レビューで挙がった **🔴 must** への追従 fix。

DL済み（`exported`）コメントを編集しても `exported` フラグが残り、`!item.exported` でフィルタする一括DLの対象外になるため、**修正後の内容が receiver に届かない**問題を解消する。

## 変更

- `widget/src/index.js` `submitComment` の編集分岐: `comment`/`reviewer` が変化したときに `exported`/`exportedAt`/`exportedFileName` をクリアし、未送信に戻す。無変更の編集では再キューしない。
- dist 再ビルド済み。

## 検証（実ブラウザ・headless Chrome / CDP ハーネス）

24/24 パス。追加した観点:
- 編集で `exported` がクリアされ未送信(1)に戻る
- 無変更編集では未送信に戻らない(0)

Refs #79 #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
