### PR TITLE
receiver: v2 batch bundle の一括 import に対応 (PR-B of #32)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -66,8 +66,8 @@ script-tag widget:
 - Optional `onSubmit(payload)` callback
 - Optional `endpoint` setting that POSTs payloads to the bundled local receiver
 - Optional Slack Incoming Webhook forwarding from the local receiver with screenshot links, image blocks, and optional file upload
-- Download mode that saves a versioned JSON bundle for each feedback item
-- Receiver inbox import for bundles created by download mode
+- Download mode that batches unsent feedback for a demo into one versioned JSON bundle (tracked with a sent flag)
+- Receiver inbox import for download-mode bundles (both single and batch)
 - Configurable delivery mode for receiver forwarding, direct Slack webhook delivery, download, or no delivery
 
 ## Embeddable Widget
@@ -170,7 +170,7 @@ node server/receive.js
 ```
 
 - Accepts payload at `POST /feedback`, storing it in `server/feedback.db` (sqlite) by default
-- Imports download-mode JSON bundles at `POST /import`, storing them in the same inbox format
+- Imports download-mode JSON bundles at `POST /import` (single v1 feedback or array-based v2 batch), storing them in the same inbox format. Duplicate ids are skipped, and the response returns `imported` / `duplicates` / `failed`
 - Renders an inbox of received feedback at `GET /`
 - The inbox has text search plus status / kind / project / demo / reviewer / source / Slack filters
 - Each feedback has a triage status (`new` / `accepted` / `fixed` / `ignored`) editable from the card; statuses persist to sqlite
@@ -280,22 +280,24 @@ window.PatchLoop.init({
 });
 ```
 
-On submit, the widget downloads `<project>-<demo>-<feedback-id>.patchloop-feedback.json`. The bundle is a single JSON file for now, not a ZIP. The format is versioned.
+In download mode, comments are not downloaded one-by-one on submit. They collect in the drawer, and the "未送信をまとめてDL（N）" button writes **all unsent comments as a single file** named `<project>-<demo>-<count>-<timestamp>.patchloop-feedback.json`. Exported comments get a sent flag (shown as "DL済み" in the list) and are excluded from the next batch download (editing a sent comment moves it back to unsent). The bundle is a single JSON file for now, not a ZIP. The format is versioned and `feedback` is an array.
 
 ```json
 {
   "kind": "patchloop-feedback-bundle",
-  "version": 1,
-  "exportedAt": "2026-06-02T00:00:00.000Z",
+  "version": 2,
+  "exportedAt": "2026-06-16T00:00:00.000Z",
   "projectId": "patchloop",
   "demoId": "plain-html-renewal-review",
-  "feedback": {
-    "id": "pl_...",
-    "screenshot": {
-      "status": "captured",
-      "dataUrl": "data:image/svg+xml;base64,..."
+  "feedback": [
+    {
+      "id": "pl_...",
+      "screenshot": {
+        "status": "captured",
+        "dataUrl": "data:image/svg+xml;base64,..."
+      }
     }
-  }
+  ]
 }
 ```
 
@@ -307,7 +309,7 @@ curl -X POST http://127.0.0.1:4000/import \
   --data-binary @patchloop-feedback.json
 ```
 
-The receiver validates the bundle version and payload shape, saves the screenshot `dataUrl` to `server/screenshots/`, and appends the imported feedback to `server/feedback.json`. Imported feedback gets `source: "import"` and `importedAt`. The receiver does not forward imported feedback to Slack; the inbox shows `Slack: skipped`.
+The receiver validates the bundle version (both the single-feedback v1 and the array-based v2 batch) and payload shape, saves each feedback's screenshot `dataUrl` to `server/screenshots/`, and appends the imported feedback to the store. Imported feedback gets `source: "import"` and `importedAt`. For a batch import, ids that already exist are skipped as duplicates (the rest still land), and the response returns `imported`, `duplicates`, and `failed`. If any payload in the bundle is invalid, the whole batch is rejected with 400 and nothing is written. The receiver does not forward imported feedback to Slack; the inbox shows `Slack: skipped`.
 
 ## Current Boundary
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ script-tag widget:
 - 任意の `onSubmit(payload)` callback
 - 任意の `endpoint` 設定で payload を receiver に POST
 - ローカル receiver から任意の Slack Incoming Webhook へ、スクショリンク / image block / 任意の file upload 付きで転送
-- Download mode で 1 feedback ごとの versioned JSON bundle を保存
-- receiver inbox から download mode の bundle を import
+- Download mode で、未送信ぶんをデモ単位でまとめた versioned JSON bundle を一括保存（送り済みフラグで管理）
+- receiver inbox から download mode の bundle（単一・batch の両方）を import
 - 設定または drawer UI から、receiver 経由送信 / Slack webhook 直送 / download / 送信なしを切り替え
 
 ## 埋め込み Widget
@@ -170,7 +170,7 @@ node server/receive.js
 ```
 
 - `POST /feedback` で payload を受け取り、デフォルトでは `server/feedback.db`（sqlite）に保存します
-- `POST /import` で download mode の JSON bundle を読み込み、通常の inbox と同じ形式で保存します
+- `POST /import` で download mode の JSON bundle（単一 feedback の v1 / 配列の v2 batch の両方）を読み込み、通常の inbox と同じ形式で保存します。重複 id はスキップし `imported` / `duplicates` / `failed` を返します
 - `GET /` で受信した feedback の一覧（inbox）を表示します
 - inbox にはテキスト検索と status / kind / project / demo / reviewer / source / Slack の絞り込みがあります
 - 各 feedback には triage status（`new` / `accepted` / `fixed` / `ignored`）があり、card 上の select から変更できます。status は sqlite に永続化されます
@@ -280,22 +280,24 @@ window.PatchLoop.init({
 });
 ```
 
-送信時に `<project>-<demo>-<feedback-id>.patchloop-feedback.json` が保存されます。この bundle は単一 JSON ファイルで、現時点では ZIP ではありません。形式は versioned です。
+download mode では、コメントするたびに自動ダウンロードはされません。コメントは drawer に溜まり、「未送信をまとめてDL（N）」ボタンを押すと、**未送信ぶんをまとめて 1 ファイル**として `<project>-<demo>-<件数>-<timestamp>.patchloop-feedback.json` に書き出します。書き出したコメントには送り済みフラグ（一覧で「DL済み」表示）が付き、次回の一括 DL からは除外されます（DL済みコメントを編集すると未送信に戻ります）。bundle は単一 JSON ファイルで、現時点では ZIP ではありません。形式は versioned で、`feedback` は配列です。
 
 ```json
 {
   "kind": "patchloop-feedback-bundle",
-  "version": 1,
-  "exportedAt": "2026-06-02T00:00:00.000Z",
+  "version": 2,
+  "exportedAt": "2026-06-16T00:00:00.000Z",
   "projectId": "patchloop",
   "demoId": "plain-html-renewal-review",
-  "feedback": {
-    "id": "pl_...",
-    "screenshot": {
-      "status": "captured",
-      "dataUrl": "data:image/svg+xml;base64,..."
+  "feedback": [
+    {
+      "id": "pl_...",
+      "screenshot": {
+        "status": "captured",
+        "dataUrl": "data:image/svg+xml;base64,..."
+      }
     }
-  }
+  ]
 }
 ```
 
@@ -307,7 +309,7 @@ curl -X POST http://127.0.0.1:4000/import \
   --data-binary @patchloop-feedback.json
 ```
 
-receiver は bundle version と payload shape を検証し、screenshot の `dataUrl` を `server/screenshots/` に保存してから `server/feedback.json` に追記します。import した feedback には `source: "import"` / `importedAt` が付きます。Slack への再転送はせず、inbox 上では `Slack: skipped` と表示されます。
+receiver は bundle version（v1 の単一 feedback / v2 の配列の両方）と payload shape を検証し、各 feedback の screenshot `dataUrl` を `server/screenshots/` に保存してから store に追記します。import した feedback には `source: "import"` / `importedAt` が付きます。batch import では、すでに存在する id は重複としてスキップし（残りは取り込む）、応答に `imported` 件数・`duplicates`・`failed` を返します。payload のどれか 1 件でも不正なら、何も書き込まずに batch 全体を 400 で拒否します。Slack への再転送はせず、inbox 上では `Slack: skipped` と表示されます。
 
 ## 現在の境界
 

--- a/server/receive.js
+++ b/server/receive.js
@@ -36,7 +36,10 @@ const GITHUB_API_BASE = trimTrailingSlash(process.env.GITHUB_API_BASE || config.
 const GITHUB_TIMEOUT_MS = numberSetting(process.env.GITHUB_TIMEOUT_MS, numberSetting(config.githubTimeoutMs, 8000));
 const GITHUB_CONFIGURED = Boolean(GITHUB_TOKEN && GITHUB_REPO);
 const IMPORT_BUNDLE_KIND = "patchloop-feedback-bundle";
-const IMPORT_BUNDLE_VERSION = 1;
+// v1 wrapped a single feedback object; v2 carries an array (batch export).
+// Both are accepted so files exported before the batch-download switch still
+// import.
+const SUPPORTED_IMPORT_BUNDLE_VERSIONS = new Set([1, 2]);
 const FEEDBACK_STATUSES = ["new", "accepted", "fixed", "ignored"];
 // Default applied to payloads received before the widget sent schemaVersion,
 // so every stored item carries a version going forward.
@@ -233,34 +236,68 @@ function handlePostFeedback(req, res) {
 
 function handlePostImport(req, res) {
   readJsonBody(req, res, async (body) => {
-    let imported;
-    let screenshot;
+    let importedList;
     try {
-      imported = normalizeImportedBundle(body);
-      screenshot = saveScreenshot(imported.screenshot, imported.id);
+      importedList = normalizeImportedBundle(body);
     } catch (error) {
       respondJson(res, error.statusCode || 400, { ok: false, error: error.message });
       return;
     }
 
     const now = new Date().toISOString();
-    const stored = {
-      schemaVersion: DEFAULT_SCHEMA_VERSION,
-      ...imported,
-      receivedAt: now,
-      importedAt: now,
-      source: "import",
-      screenshot,
-      integrations: {
-        slack: { status: "skipped", reason: "import" }
-      }
-    };
+    const ids = [];
+    const duplicates = [];
+    const failed = [];
 
-    await store.insert(stored);
-    console.log(`[PatchLoop receiver] imported feedback id=${stored.id || "?"} comment="${truncateText(stored.comment || "", 60)}"`);
-    respondJson(res, 201, {
-      ok: true,
-      id: stored.id,
+    // Best-effort per item: a duplicate id (re-imported batch) is skipped, not
+    // fatal, so the rest of the bundle still lands. Validation already ran for
+    // the whole list, so failures here are write-time only.
+    for (const imported of importedList) {
+      let screenshot;
+      try {
+        screenshot = saveScreenshot(imported.screenshot, imported.id);
+      } catch (error) {
+        failed.push({ id: imported.id, error: error.message });
+        continue;
+      }
+
+      const stored = {
+        schemaVersion: DEFAULT_SCHEMA_VERSION,
+        ...imported,
+        receivedAt: now,
+        importedAt: now,
+        source: "import",
+        screenshot,
+        integrations: {
+          slack: { status: "skipped", reason: "import" }
+        }
+      };
+
+      try {
+        await store.insert(stored);
+        ids.push(stored.id);
+        console.log(`[PatchLoop receiver] imported feedback id=${stored.id || "?"} comment="${truncateText(stored.comment || "", 60)}"`);
+      } catch (error) {
+        // The insert failed, so drop the screenshot we just wrote for it
+        // (saveScreenshot names files uniquely, so this never touches an
+        // existing record's screenshot).
+        await deleteScreenshotFile(screenshot);
+        if (error.statusCode === 409) {
+          duplicates.push(stored.id);
+        } else {
+          failed.push({ id: stored.id, error: error.message });
+        }
+      }
+    }
+
+    const status = ids.length > 0 ? 201 : duplicates.length > 0 ? 409 : 400;
+    respondJson(res, status, {
+      ok: ids.length > 0,
+      id: ids[0],
+      ids,
+      imported: ids.length,
+      duplicates,
+      failed,
       count: await store.count(),
       source: "import"
     });
@@ -498,21 +535,32 @@ function readJsonBody(req, res, onJson) {
   });
 }
 
+// Resolves a bundle (single or batch) into a list of normalized payloads.
+// Validation runs over every payload up front, so a batch with one bad item
+// is rejected whole before anything is written.
 function normalizeImportedBundle(body) {
   requirePlainObject(body, "Import body");
 
-  let payload;
+  let feedback;
   if (body.kind === IMPORT_BUNDLE_KIND) {
-    if (body.version !== IMPORT_BUNDLE_VERSION) {
+    if (!SUPPORTED_IMPORT_BUNDLE_VERSIONS.has(body.version)) {
       throw httpError(`Unsupported PatchLoop bundle version: ${body.version}`, 400);
     }
-    payload = body.feedback;
-  } else if (body.feedback) {
-    payload = body.feedback;
+    feedback = body.feedback;
+  } else if (body.feedback !== undefined) {
+    feedback = body.feedback;
   } else {
-    payload = body;
+    feedback = body;
   }
 
+  const list = Array.isArray(feedback) ? feedback : [feedback];
+  if (list.length === 0) {
+    throw httpError("Import bundle contains no feedback", 400);
+  }
+  return list.map(normalizeImportedPayload);
+}
+
+function normalizeImportedPayload(payload) {
   validateFeedbackPayload(payload);
   const imported = JSON.parse(JSON.stringify(payload));
   delete imported.delivery;
@@ -520,6 +568,11 @@ function normalizeImportedBundle(body) {
   delete imported.receivedAt;
   delete imported.importedAt;
   delete imported.source;
+  // Local-only export markers (set by the widget after a batch download) must
+  // never reach the stored record.
+  delete imported.exported;
+  delete imported.exportedAt;
+  delete imported.exportedFileName;
   return imported;
 }
 

--- a/server/receive.js
+++ b/server/receive.js
@@ -546,6 +546,14 @@ function normalizeImportedBundle(body) {
     if (!SUPPORTED_IMPORT_BUNDLE_VERSIONS.has(body.version)) {
       throw httpError(`Unsupported PatchLoop bundle version: ${body.version}`, 400);
     }
+    // Each version pins its feedback shape, so a malformed producer (v1 array
+    // or v2 single object) is rejected instead of silently reinterpreted.
+    if (body.version === 1 && Array.isArray(body.feedback)) {
+      throw httpError("PatchLoop bundle version 1 expects a single feedback object", 400);
+    }
+    if (body.version === 2 && !Array.isArray(body.feedback)) {
+      throw httpError("PatchLoop bundle version 2 expects a feedback array", 400);
+    }
     feedback = body.feedback;
   } else if (body.feedback !== undefined) {
     feedback = body.feedback;
@@ -600,7 +608,26 @@ function validateFeedbackPayload(payload) {
   if (payload.target.selector != null) requireString(payload.target.selector, "feedback.target.selector");
   if (payload.target.text != null) requireString(payload.target.text, "feedback.target.text");
   if (payload.target.area != null) requirePlainObject(payload.target.area, "feedback.target.area");
-  if (payload.screenshot != null) requirePlainObject(payload.screenshot, "feedback.screenshot");
+  if (payload.screenshot != null) {
+    requirePlainObject(payload.screenshot, "feedback.screenshot");
+    validateScreenshotContent(payload.screenshot);
+  }
+}
+
+// Validates the screenshot's data URL / mime / size without writing a file, so
+// a batch import can reject every bad item up front (preserving the all-or-
+// nothing guarantee) instead of failing mid-write after some inserts landed.
+// Mirrors the checks saveScreenshot performs before persisting.
+function validateScreenshotContent(screenshot) {
+  if (screenshot.status && screenshot.status !== "captured") return;
+  if (!screenshot.dataUrl) return;
+  const parsed = parseDataUrl(screenshot.dataUrl);
+  if (!extensionForMimeType(parsed.mimeType)) {
+    throw httpError(`Unsupported screenshot mime type: ${parsed.mimeType}`, 400);
+  }
+  if (parsed.buffer.length > SCREENSHOT_MAX_BYTES) {
+    throw httpError(`Screenshot too large: ${parsed.buffer.length} bytes exceeds ${SCREENSHOT_MAX_BYTES}`, 413);
+  }
 }
 
 function requirePlainObject(value, label) {

--- a/server/static/inbox.js
+++ b/server/static/inbox.js
@@ -31,7 +31,12 @@
       if (!response.ok) {
         throw new Error(result.error || "Import failed");
       }
-      status.textContent = "Imported " + (result.id || "feedback") + ". Reloading...";
+      const skipped = (result.duplicates && result.duplicates.length) || 0;
+      const failed = (result.failed && result.failed.length) || 0;
+      status.textContent = "Imported " + (result.imported || 0) + " feedback"
+        + (skipped ? " (" + skipped + " duplicate skipped)" : "")
+        + (failed ? " (" + failed + " failed)" : "")
+        + ". Reloading...";
       window.location.reload();
     } catch (error) {
       status.dataset.state = "error";

--- a/server/static/inbox.js
+++ b/server/static/inbox.js
@@ -28,16 +28,19 @@
         body: text
       });
       const result = await response.json().catch(() => ({}));
-      if (!response.ok) {
+      // A genuine error (400/500) has no batch summary; a 409 all-duplicates
+      // response still carries imported/duplicates and is shown, not thrown.
+      if (!response.ok && result.imported === undefined) {
         throw new Error(result.error || "Import failed");
       }
+      const imported = result.imported || 0;
       const skipped = (result.duplicates && result.duplicates.length) || 0;
       const failed = (result.failed && result.failed.length) || 0;
-      status.textContent = "Imported " + (result.imported || 0) + " feedback"
+      status.textContent = "Imported " + imported + " feedback"
         + (skipped ? " (" + skipped + " duplicate skipped)" : "")
         + (failed ? " (" + failed + " failed)" : "")
-        + ". Reloading...";
-      window.location.reload();
+        + (imported ? ". Reloading..." : ".");
+      if (imported) window.location.reload();
     } catch (error) {
       status.dataset.state = "error";
       status.textContent = error.message;

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -184,6 +184,48 @@ test("POST /import rejects the whole batch when one payload is invalid", async (
   assert.deepEqual(await readStoredFeedback(receiver.dbPath), []);
 });
 
+test("POST /import rejects the whole batch when a later screenshot is invalid", async (t) => {
+  const receiver = await startReceiver(t);
+  const bad = feedbackPayload("pl_badshot_2");
+  bad.screenshot = { status: "captured", kind: "viewport-svg", dataUrl: "data:text/plain;base64,Zm9v" };
+
+  const response = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    feedback: [feedbackPayload("pl_goodshot_1"), bad]
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.ok, false);
+  assert.match(response.body.error, /Unsupported screenshot mime type/);
+  // The first (valid) item must not have landed before the bad one failed.
+  assert.deepEqual(await readStoredFeedback(receiver.dbPath), []);
+  const files = await fs.readdir(receiver.screenshotDir).catch(() => []);
+  assert.equal(files.length, 0);
+});
+
+test("POST /import enforces the feedback shape per bundle version", async (t) => {
+  const receiver = await startReceiver(t);
+
+  const v1Array = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 1,
+    feedback: [feedbackPayload("pl_shape_1")]
+  });
+  assert.equal(v1Array.status, 400);
+  assert.match(v1Array.body.error, /version 1 expects a single feedback object/);
+
+  const v2Single = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    feedback: feedbackPayload("pl_shape_2")
+  });
+  assert.equal(v2Single.status, 400);
+  assert.match(v2Single.body.error, /version 2 expects a feedback array/);
+
+  assert.deepEqual(await readStoredFeedback(receiver.dbPath), []);
+});
+
 test("POST /feedback/:id/status updates triage status and persists it", async (t) => {
   const receiver = await startReceiver(t);
   const payload = feedbackPayload("pl_status_1");

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -104,6 +104,86 @@ test("POST /import rejects unsupported bundle versions", async (t) => {
   assert.deepEqual(await readStoredFeedback(receiver.dbPath), []);
 });
 
+test("POST /import stores every feedback in a v2 batch bundle", async (t) => {
+  const receiver = await startReceiver(t);
+
+  const response = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    exportedAt: "2026-06-03T00:00:00.000Z",
+    projectId: "patchloop",
+    demoId: "receiver-test",
+    feedback: [
+      { ...feedbackPayload("pl_batch_1"), exported: true, exportedAt: "2026-06-03T01:00:00.000Z" },
+      feedbackPayload("pl_batch_2"),
+      feedbackPayload("pl_batch_3")
+    ]
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.ok, true);
+  assert.equal(response.body.imported, 3);
+  assert.deepEqual(response.body.ids, ["pl_batch_1", "pl_batch_2", "pl_batch_3"]);
+  assert.deepEqual(response.body.duplicates, []);
+  assert.deepEqual(response.body.failed, []);
+  assert.equal(response.body.count, 3);
+
+  const stored = await readStoredFeedback(receiver.dbPath);
+  assert.equal(stored.length, 3);
+  for (const item of stored) {
+    assert.equal(item.source, "import");
+    // Local-only export markers must not be persisted.
+    assert.equal(item.exported, undefined);
+    assert.equal(item.exportedAt, undefined);
+    assert.equal(item.screenshot.status, "saved");
+  }
+});
+
+test("POST /import skips duplicate ids in a batch but lands the rest", async (t) => {
+  const receiver = await startReceiver(t);
+  await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    feedback: [feedbackPayload("pl_dup_1")]
+  });
+
+  const response = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    feedback: [feedbackPayload("pl_dup_1"), feedbackPayload("pl_dup_2")]
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.imported, 1);
+  assert.deepEqual(response.body.ids, ["pl_dup_2"]);
+  assert.deepEqual(response.body.duplicates, ["pl_dup_1"]);
+  assert.equal(response.body.count, 2);
+
+  // The duplicate did not orphan a screenshot: exactly two files for two rows.
+  const stored = await readStoredFeedback(receiver.dbPath);
+  const files = await fs.readdir(receiver.screenshotDir);
+  assert.equal(stored.length, 2);
+  assert.equal(files.length, 2);
+});
+
+test("POST /import rejects the whole batch when one payload is invalid", async (t) => {
+  const receiver = await startReceiver(t);
+  const bad = feedbackPayload("pl_bad_2");
+  bad.reviewer = "";
+
+  const response = await postJson(`${receiver.baseUrl}/import`, {
+    kind: "patchloop-feedback-bundle",
+    version: 2,
+    feedback: [feedbackPayload("pl_good_1"), bad]
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.ok, false);
+  assert.match(response.body.error, /feedback\.reviewer must not be empty/);
+  // Nothing was written — validation runs before any insert.
+  assert.deepEqual(await readStoredFeedback(receiver.dbPath), []);
+});
+
 test("POST /feedback/:id/status updates triage status and persists it", async (t) => {
   const receiver = await startReceiver(t);
   const payload = feedbackPayload("pl_status_1");


### PR DESCRIPTION
## 概要

#32 の PR-B（receiver 側）。PR #79 で widget が出すようになった **v2 batch bundle（`feedback` が配列）を `POST /import` で取り込めるように**する。これで「一括ダウンロード → 一括取り込み」が噛み合い、#32 が完結する。

## 変更点

- **v1 / v2 両対応**: `SUPPORTED_IMPORT_BUNDLE_VERSIONS = {1, 2}`。v1（単一 feedback）も後方互換で受理。
- **一括正規化**: `normalizeImportedBundle` が payload のリストを返す。**全件を先に検証**し、1 件でも不正なら何も書かず batch 全体を 400 で拒否（部分書き込みを作らない）。
- **best-effort 取り込み**: 既存 id は重複としてスキップし残りは取り込む。応答に `imported` / `ids` / `duplicates` / `failed` / `count` を返す。全件重複なら 409。
- **orphan 防止**: 重複・失敗時は直前に書いた screenshot をロールバック削除。`saveScreenshot` はファイル名が一意（id+timestamp+random）なので既存レコードの screenshot は触らない。
- **ローカル専用フラグ除去**: `exported` / `exportedAt` / `exportedFileName` は保存時に削除。
- **inbox UI**: import ステータスを「Imported N feedback (M duplicate skipped)…」の batch サマリ表示に更新。
- **テスト 3 件追加**: batch 取り込み / 重複スキップ＋orphan なし / 不正で全拒否。
- **README / README.en** を batch download・batch import に更新。

## 検証

- `npm run check`（lint + dist 鮮度 + test **65 件**）green
- 実機: PR-A の widget が実際に書き出した v2 ファイルを receiver に `POST /import` → 2 件取り込み（201）、同ファイル再 POST で全件 `duplicates`（409）・orphan screenshot なしを確認

Closes #32. Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
