### PR TITLE
receiver: feedback の 409 時に screenshot 孤児化 + Slack 誤通知を解消 (#82)

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -216,11 +216,24 @@ function handlePostFeedback(req, res) {
       ...payload,
       screenshot
     };
+
+    // Persist before notifying. A failed insert (e.g. a duplicate id -> 409)
+    // must not leave the screenshot we just wrote as an orphan, and only a
+    // feedback that actually landed should trigger a Slack notification. This
+    // mirrors the cleanup the import path already does on insert failure.
+    try {
+      await store.insert(stored);
+    } catch (error) {
+      await deleteScreenshotFile(screenshot);
+      respondJson(res, error.statusCode || 500, { ok: false, error: error.message });
+      return;
+    }
+
     stored.integrations = {
       ...(stored.integrations || {}),
       slack: await deliverToSlack(stored)
     };
-    await store.insert(stored);
+    await store.update(stored.id, { integrations: stored.integrations });
     const slackLog = stored.integrations.slack.status === "disabled"
       ? ""
       : ` slack=${stored.integrations.slack.status}`;

--- a/server/receive.js
+++ b/server/receive.js
@@ -793,6 +793,15 @@ function saveScreenshot(screenshot, id) {
 
   const metadata = { ...screenshot };
   delete metadata.dataUrl;
+  // path / url / fileName / bytes are server-owned and only set below when we
+  // actually write the file. Never trust client-supplied values: otherwise a
+  // crafted screenshot (e.g. {status:"saved", path:"<another record's file>"})
+  // could survive into the stored record and point cleanup
+  // (deleteScreenshotFile) or links at a file this request never wrote.
+  delete metadata.path;
+  delete metadata.url;
+  delete metadata.fileName;
+  delete metadata.bytes;
 
   if (screenshot.status && screenshot.status !== "captured") {
     return metadata;

--- a/server/receive.js
+++ b/server/receive.js
@@ -793,15 +793,16 @@ function saveScreenshot(screenshot, id) {
 
   const metadata = { ...screenshot };
   delete metadata.dataUrl;
-  // path / url / fileName / bytes are server-owned and only set below when we
-  // actually write the file. Never trust client-supplied values: otherwise a
-  // crafted screenshot (e.g. {status:"saved", path:"<another record's file>"})
-  // could survive into the stored record and point cleanup
-  // (deleteScreenshotFile) or links at a file this request never wrote.
+  // path / url / fileName are server-owned and only set below when we actually
+  // write the file. Never trust client-supplied values: otherwise a crafted
+  // screenshot (e.g. {status:"saved", path:"<another record's file>"}) could
+  // survive into the stored record and point cleanup (deleteScreenshotFile) or
+  // serving links at a file this request never wrote. bytes/maxBytes are kept:
+  // the widget legitimately sends them for the status:"omitted" too-large case
+  // (formatScreenshotStatus renders them), and they are not used for file I/O.
   delete metadata.path;
   delete metadata.url;
   delete metadata.fileName;
-  delete metadata.bytes;
 
   if (screenshot.status && screenshot.status !== "captured") {
     return metadata;

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -686,6 +686,22 @@ test("POST /feedback 409 cleanup cannot delete another record's screenshot", asy
   assert.deepEqual(after, [victimFile]);
 });
 
+test("POST /feedback keeps omitted screenshot metadata (bytes/maxBytes)", async (t) => {
+  const receiver = await startReceiver(t);
+  const payload = feedbackPayload("pl_omitted");
+  // The widget sends this shape when the capture is too large; receiver renders
+  // "omitted: <bytes> bytes exceeds <maxBytes>". Stripping server-owned fields
+  // must not drop this legitimate client metadata.
+  payload.screenshot = { status: "omitted", reason: "too-large", kind: "viewport-svg", bytes: 99999, maxBytes: 1000 };
+  const response = await postJson(`${receiver.baseUrl}/feedback`, payload);
+  assert.equal(response.status, 201);
+
+  const stored = await readStoredFeedback(receiver.dbPath);
+  assert.equal(stored[0].screenshot.status, "omitted");
+  assert.equal(stored[0].screenshot.bytes, 99999);
+  assert.equal(stored[0].screenshot.maxBytes, 1000);
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -667,6 +667,25 @@ test("POST /feedback rejects a duplicate id instead of overwriting", async (t) =
   assert.equal(files.length, 1);
 });
 
+test("POST /feedback 409 cleanup cannot delete another record's screenshot", async (t) => {
+  const receiver = await startReceiver(t);
+  await postJson(`${receiver.baseUrl}/feedback`, feedbackPayload("pl_victim"));
+  const before = await fs.readdir(receiver.screenshotDir);
+  assert.equal(before.length, 1);
+  const victimFile = before[0];
+
+  // Re-use an existing id (-> 409) with a crafted screenshot that points at the
+  // victim's stored file. saveScreenshot must strip the client-supplied path so
+  // the 409 cleanup (deleteScreenshotFile) cannot touch a file we did not write.
+  const attack = feedbackPayload("pl_victim");
+  attack.screenshot = { status: "saved", path: path.join(receiver.screenshotDir, victimFile) };
+  const response = await postJson(`${receiver.baseUrl}/feedback`, attack);
+  assert.equal(response.status, 409);
+
+  const after = await fs.readdir(receiver.screenshotDir);
+  assert.deepEqual(after, [victimFile]);
+});
+
 async function startReceiver(t, extraEnv = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "patchloop-receiver-test-"));
   const port = await getFreePort();

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -660,6 +660,11 @@ test("POST /feedback rejects a duplicate id instead of overwriting", async (t) =
   const stored = await readStoredFeedback(receiver.dbPath);
   assert.equal(stored.length, 1);
   assert.equal(stored[0].comment, "original");
+
+  // The rejected duplicate must not orphan the screenshot it wrote: one stored
+  // row means exactly one screenshot file (regression for #82).
+  const files = await fs.readdir(receiver.screenshotDir);
+  assert.equal(files.length, 1);
 });
 
 async function startReceiver(t, extraEnv = {}) {


### PR DESCRIPTION
## 概要
`POST /feedback` の副作用順序を直し、重複 id（409）時の **screenshot 孤児化** と **保存されない feedback への Slack 誤通知** を解消する。Closes #82。

## 背景
`handlePostFeedback` は「screenshot 書き込み → `deliverToSlack` → `store.insert`」の順だった（`server/receive.js:204-223`）。`store.insert` は重複 id で 409 を throw するが、その後始末が無く:
- (a) 永続化されない feedback の screenshot が `SCREENSHOT_DIR` に孤児として残る（容量リーク）
- (b) inbox に存在しない feedback について Slack 通知だけが飛ぶ

import 経路は insert 失敗時に `deleteScreenshotFile`（L284）で後始末しており、feedback 経路だけが非対称だった。

## 変更
- `store.insert` を `deliverToSlack` の **前** に移動。失敗時は `deleteScreenshotFile(screenshot)` で後始末し、エラー応答して中断（import 経路と同じパターン）。
- Slack 結果は永続化成功後に `store.update` で record に書き戻す（既存のレスポンス形・保存内容は不変）。

## テスト
- `npm run check`（eslint + build --check + 67 tests）green。
- 回帰テスト追加: 「`POST /feedback` rejects a duplicate id」に、409 後 screenshot ファイルが 1 件のみ（孤児を残さない）を追加。修正前はこのアサートで 2 件になり fail する。

## スコープ外（別 issue）
- Slack 送信そのものを応答パスから外す件は #85。
- 「Slack が呼ばれないこと」を直接アサートする結合テストは `startMockSlack` が前提で #86。本 PR は insert→Slack の構造で誤通知を防ぐ。
