### PR TITLE
widget: 永続フィードバックの URL 一致を正規化し silent data loss を防ぐ (#84)

### DIFF
--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -287,6 +287,34 @@ function flattenRulesForSnapshot(rules, mediaMatches) {
 
 return { freezeViewportUnits, flattenRulesForSnapshot };
 })();
+// --- widget/src/url.js ---
+const __pl_widget_src_url = (() => {
+// Page-identity helpers for persisted feedback.
+//
+// Saved feedback is keyed by the page it was left on. Using the full
+// `location.href` (which includes the query string and hash) is too strict:
+// after anchor navigation (`#section`), tracking params (`?utm=...`), or a
+// normalizing redirect, the URL no longer matches byte-for-byte and the saved
+// feedback is silently dropped — and then overwritten. The envelope is already
+// scoped by projectId/demoId, so comparing only origin + pathname is enough.
+
+function normalizePageUrl(url, base) {
+  try {
+    const parsed = new URL(url, base);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch (_) {
+    return "";
+  }
+}
+
+function samePersistedPage(storedUrl, currentUrl) {
+  const stored = normalizePageUrl(storedUrl, currentUrl);
+  const current = normalizePageUrl(currentUrl, currentUrl);
+  return stored !== "" && stored === current;
+}
+
+return { normalizePageUrl, samePersistedPage };
+})();
 // --- shared/format.js ---
 const __pl_shared_format = (() => {
 // Formatting helpers shared by the widget (bundled into dist) and the
@@ -352,6 +380,7 @@ const { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarget
 const { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } = __pl_widget_src_anchoring;
 const { selectorFor, textFor } = __pl_widget_src_selector;
 const { freezeViewportUnits, flattenRulesForSnapshot } = __pl_widget_src_snapshot_css;
+const { samePersistedPage } = __pl_widget_src_url;
 const { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } = __pl_shared_format;
 
 const DEFAULTS = {
@@ -1205,7 +1234,7 @@ function isMatchingFeedbackEnvelope(value) {
   if (value.version !== FEEDBACK_STORAGE_VERSION) return false;
   if (value.projectId !== state.options.projectId) return false;
   if (value.demoId !== state.options.demoId) return false;
-  if (value.pageUrl !== window.location.href) return false;
+  if (!samePersistedPage(value.pageUrl, window.location.href)) return false;
   return Array.isArray(value.feedback);
 }
 

--- a/dist/patchloop-widget.js
+++ b/dist/patchloop-widget.js
@@ -308,8 +308,13 @@ function normalizePageUrl(url, base) {
 }
 
 function samePersistedPage(storedUrl, currentUrl) {
-  const stored = normalizePageUrl(storedUrl, currentUrl);
-  const current = normalizePageUrl(currentUrl, currentUrl);
+  if (typeof storedUrl !== "string" || storedUrl === "") return false;
+  // The stored pageUrl is always a full href (the save side writes
+  // window.location.href). Parse both WITHOUT a base so a missing, empty,
+  // relative, or otherwise malformed stored value cannot be resolved against
+  // the current page and falsely match it.
+  const stored = normalizePageUrl(storedUrl, undefined);
+  const current = normalizePageUrl(currentUrl, undefined);
   return stored !== "" && stored === current;
 }
 

--- a/test/widget-url.test.js
+++ b/test/widget-url.test.js
@@ -34,3 +34,11 @@ test("samePersistedPage distinguishes different paths and origins", () => {
 test("samePersistedPage is false when the current url is unparseable", () => {
   assert.equal(samePersistedPage("https://demo.example/app", "not a url"), false);
 });
+
+test("samePersistedPage rejects a missing, empty, or relative stored url", () => {
+  // The stored pageUrl must be a full href; an empty/relative value must not be
+  // resolved against the current page and falsely match it.
+  assert.equal(samePersistedPage("", "https://demo.example/app"), false);
+  assert.equal(samePersistedPage(undefined, "https://demo.example/app"), false);
+  assert.equal(samePersistedPage("/app", "https://demo.example/app"), false);
+});

--- a/test/widget-url.test.js
+++ b/test/widget-url.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { normalizePageUrl, samePersistedPage } = require("../widget/src/url.js");
+
+test("normalizePageUrl keeps origin and pathname, drops query and hash", () => {
+  assert.equal(normalizePageUrl("https://demo.example/app?utm=x#sec"), "https://demo.example/app");
+  assert.equal(normalizePageUrl("https://demo.example/app/"), "https://demo.example/app/");
+});
+
+test("normalizePageUrl resolves a relative url against the base", () => {
+  assert.equal(normalizePageUrl("/app?q=1", "https://demo.example/other#h"), "https://demo.example/app");
+});
+
+test("normalizePageUrl returns empty string for unparseable input", () => {
+  assert.equal(normalizePageUrl("not a url"), "");
+  assert.equal(normalizePageUrl(undefined), "");
+});
+
+test("samePersistedPage ignores query and hash on the same page", () => {
+  assert.equal(samePersistedPage("https://demo.example/app", "https://demo.example/app#section"), true);
+  assert.equal(samePersistedPage("https://demo.example/app?a=1", "https://demo.example/app?b=2"), true);
+  // A full href stored by an older build still matches after a hash is added.
+  assert.equal(samePersistedPage("https://demo.example/app?old=1#top", "https://demo.example/app"), true);
+});
+
+test("samePersistedPage distinguishes different paths and origins", () => {
+  assert.equal(samePersistedPage("https://demo.example/app", "https://demo.example/other"), false);
+  assert.equal(samePersistedPage("https://demo.example/app", "https://evil.example/app"), false);
+});
+
+test("samePersistedPage is false when the current url is unparseable", () => {
+  assert.equal(samePersistedPage("https://demo.example/app", "not a url"), false);
+});

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -2,6 +2,7 @@ import { pointFromClient, rectFromPoints, rectContainsArea, pointFromStoredTarge
 import { pointAnchorOffsets, areaAnchorOffsets, roundedAnchor, geometryFromAnchor, viewportDiffersFromCreation } from "./anchoring.js";
 import { selectorFor, textFor } from "./selector.js";
 import { freezeViewportUnits, flattenRulesForSnapshot } from "./snapshot-css.js";
+import { samePersistedPage } from "./url.js";
 import { truncateText, present, escapeHtml, escapeXml, slackEscape, formatSlackCode, formatSlackLink, formatViewport, formatTarget } from "../../shared/format.js";
 
 const DEFAULTS = {
@@ -855,7 +856,7 @@ function isMatchingFeedbackEnvelope(value) {
   if (value.version !== FEEDBACK_STORAGE_VERSION) return false;
   if (value.projectId !== state.options.projectId) return false;
   if (value.demoId !== state.options.demoId) return false;
-  if (value.pageUrl !== window.location.href) return false;
+  if (!samePersistedPage(value.pageUrl, window.location.href)) return false;
   return Array.isArray(value.feedback);
 }
 

--- a/widget/src/url.js
+++ b/widget/src/url.js
@@ -1,0 +1,23 @@
+// Page-identity helpers for persisted feedback.
+//
+// Saved feedback is keyed by the page it was left on. Using the full
+// `location.href` (which includes the query string and hash) is too strict:
+// after anchor navigation (`#section`), tracking params (`?utm=...`), or a
+// normalizing redirect, the URL no longer matches byte-for-byte and the saved
+// feedback is silently dropped — and then overwritten. The envelope is already
+// scoped by projectId/demoId, so comparing only origin + pathname is enough.
+
+export function normalizePageUrl(url, base) {
+  try {
+    const parsed = new URL(url, base);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch (_) {
+    return "";
+  }
+}
+
+export function samePersistedPage(storedUrl, currentUrl) {
+  const stored = normalizePageUrl(storedUrl, currentUrl);
+  const current = normalizePageUrl(currentUrl, currentUrl);
+  return stored !== "" && stored === current;
+}

--- a/widget/src/url.js
+++ b/widget/src/url.js
@@ -17,7 +17,12 @@ export function normalizePageUrl(url, base) {
 }
 
 export function samePersistedPage(storedUrl, currentUrl) {
-  const stored = normalizePageUrl(storedUrl, currentUrl);
-  const current = normalizePageUrl(currentUrl, currentUrl);
+  if (typeof storedUrl !== "string" || storedUrl === "") return false;
+  // The stored pageUrl is always a full href (the save side writes
+  // window.location.href). Parse both WITHOUT a base so a missing, empty,
+  // relative, or otherwise malformed stored value cannot be resolved against
+  // the current page and falsely match it.
+  const stored = normalizePageUrl(storedUrl, undefined);
+  const current = normalizePageUrl(currentUrl, undefined);
   return stored !== "" && stored === current;
 }


### PR DESCRIPTION
## 概要
永続フィードバックの「同じページか」判定を `location.href` 完全一致から **origin + pathname** に正規化し、ハッシュ／クエリ変化やリダイレクト後の **silent data loss** を防ぐ。Closes #84。

## 背景
`isMatchingFeedbackEnvelope` が `value.pageUrl !== window.location.href`（`widget/src/index.js:858`）で比較していたため、`location.href` に含まれるハッシュ（`#section`）・クエリ（`?utm=...`）の変化や正規化リダイレクトが起きると envelope 不一致と判定され、保存済みフィードバックが復元されない。さらにその後の操作で `persistFeedbackList()` が新しい `pageUrl` で旧データを上書きし、アクセス不能化していた。envelope は `projectId`/`demoId` で既にスコープ済みなので URL 比較は過剰に厳格だった。

## 変更
- 純モジュール `widget/src/url.js` を追加（`normalizePageUrl` / `samePersistedPage`）。`new URL` で origin+pathname を取り、query/hash を無視して比較する。
- `isMatchingFeedbackEnvelope` を `samePersistedPage(value.pageUrl, window.location.href)` に変更。
- 保存側（`feedbackStorageEnvelope` の `pageUrl: window.location.href`）は full href のまま据え置き → **後方互換**（旧 full href の stored 値も正規化比較で一致する）。
- `dist/patchloop-widget.js` を再生成。

## テスト
- `npm run check`（eslint + build --check + **75 tests**）green。
- 単体テスト `test/widget-url.test.js` 追加: query/hash 無視で一致、異なる path/origin は不一致、旧 full href も一致、unparseable 入力の扱い。

## 補足
- widget コア `index.js` 全体の単体テスト不足は別途 #86。本 PR はロジックを純モジュールに切り出して直接テストした。
