### PR TITLE
receiver: GitHub Issue 作成を直列化し重複 Issue(TOCTOU) を防ぐ (#83)

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -370,6 +370,13 @@ function handlePostStatus(req, res, id) {
   });
 }
 
+// Serializes GitHub issue creation per feedback id. The create flow is
+// read -> network -> write with awaits in between, so two concurrent POSTs for
+// the same id could both pass the "already created" guard and open duplicate
+// issues. An in-flight marker (held only for the duration of one create) makes
+// the second request fail fast instead.
+const githubIssueInFlight = new Set();
+
 function handlePostGitHubIssue(req, res, id) {
   readJsonBody(req, res, async () => {
     if (!GITHUB_CONFIGURED) {
@@ -389,14 +396,23 @@ function handlePostGitHubIssue(req, res, id) {
       return;
     }
 
-    const github = await createGitHubIssue(item);
-    await store.update(id, { integrations: { ...(item.integrations || {}), github } });
-    console.log(`[PatchLoop receiver] github issue ${github.status} id=${id}${github.url ? ` url=${github.url}` : ""}`);
+    if (githubIssueInFlight.has(id)) {
+      respondJson(res, 409, { ok: false, error: `GitHub issue creation already in progress: ${id}` });
+      return;
+    }
+    githubIssueInFlight.add(id);
+    try {
+      const github = await createGitHubIssue(item);
+      await store.update(id, { integrations: { ...(item.integrations || {}), github } });
+      console.log(`[PatchLoop receiver] github issue ${github.status} id=${id}${github.url ? ` url=${github.url}` : ""}`);
 
-    if (github.status === "created") {
-      respondJson(res, 201, { ok: true, github });
-    } else {
-      respondJson(res, 502, { ok: false, error: github.error || "GitHub issue creation failed", github });
+      if (github.status === "created") {
+        respondJson(res, 201, { ok: true, github });
+      } else {
+        respondJson(res, 502, { ok: false, error: github.error || "GitHub issue creation failed", github });
+      }
+    } finally {
+      githubIssueInFlight.delete(id);
     }
   });
 }

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -283,6 +283,37 @@ test("POST /feedback/:id/github-issue creates an issue via the GitHub API", asyn
   assert.equal(github.requests.length, 1);
 });
 
+test("POST /feedback/:id/github-issue serializes concurrent requests (no duplicate issue)", async (t) => {
+  // Respond slowly so both requests overlap on the server: the first holds the
+  // in-flight marker while the second arrives.
+  const github = await startMockGitHub(t, (res) => {
+    setTimeout(() => {
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ number: 7, html_url: "https://github.com/acme/demo/issues/7" }));
+    }, 60);
+  });
+  const receiver = await startReceiver(t, {
+    GITHUB_TOKEN: "test-token",
+    GITHUB_REPO: "acme/demo",
+    GITHUB_API_BASE: github.baseUrl
+  });
+  const payload = feedbackPayload("pl_github_concurrent");
+  await postJson(`${receiver.baseUrl}/feedback`, payload);
+
+  const [a, b] = await Promise.all([
+    postJson(`${receiver.baseUrl}/feedback/${payload.id}/github-issue`, {}),
+    postJson(`${receiver.baseUrl}/feedback/${payload.id}/github-issue`, {})
+  ]);
+
+  // Exactly one creates the issue (201); the other is rejected (409). Only one
+  // request reaches the GitHub API, so no duplicate issue is opened.
+  assert.deepEqual([a.status, b.status].sort(), [201, 409]);
+  assert.equal(github.requests.length, 1);
+
+  const stored = await readStoredFeedback(receiver.dbPath);
+  assert.equal(stored[0].integrations.github.status, "created");
+});
+
 test("POST /feedback/:id/github-issue persists failures and requires configuration", async (t) => {
   const unconfigured = await startReceiver(t);
   const payload = feedbackPayload("pl_github_2");


### PR DESCRIPTION
## 概要
GitHub Issue 作成を feedback id ごとに直列化し、並行 POST による **重複 Issue（TOCTOU）** を防ぐ。Closes #83。

## 背景
`handlePostGitHubIssue` は read(`store.get`) → network(`createGitHubIssue`) → write(`store.update`) の間に await を挟む（`server/receive.js:373-`）。同一 feedback id への POST が 2 本ほぼ同時に来ると、両方とも update 前の状態を read して「already created」ガードを通過し、それぞれ GitHub API を叩いて Issue を 2 件作る。GitHub API に冪等キーは無く、UI の `button.disabled` は同一タブの連打しか防がない。

## 変更
- module スコープに `githubIssueInFlight`（`Set`）を追加。create 中の feedback id を保持。
- 「already created」ガードの後に in-flight チェックを追加。進行中の id への 2 本目は `409`（in progress）で fail-fast。
- create→update を try/finally で囲み、完了・失敗いずれでも `finally` でマーカー解除（失敗後の再試行は可能）。
- `has()`+`add()` は `await store.get` の後に同期連続で実行＝割り込み不可。

## テスト
- `npm run check`（eslint + build --check + **77 tests**）green。
- 回帰テスト追加: 遅延応答の mock GitHub に対し並行 2 POST → ステータスは `201`/`409` が各 1、GitHub API への到達は **1 回のみ**（重複 Issue なし）。修正前は両方 201・API 2 回で fail する。

## 補足
- 単一プロセス前提の直列化（現行の receiver 運用と整合）。複数プロセス水平展開時の排他は #43 のハードリング文脈（DB ロック等）で別途。
