### PR TITLE
receiver: screenshot 配信に CSP/nosniff を付け SVG stored XSS を封じる (#44)

### DIFF
--- a/server/receive.js
+++ b/server/receive.js
@@ -798,7 +798,16 @@ function handleGetScreenshot(req, res) {
     }
     res.writeHead(200, {
       "Content-Type": contentTypeForPath(screenshotPath),
-      "Cache-Control": "no-store"
+      "Cache-Control": "no-store",
+      // Screenshots are attacker-controlled: an SVG can carry <script> or
+      // onload. These headers neutralize the stored-XSS vector when the file is
+      // opened as a top-level document (e.g. the inbox's target=_blank link or
+      // a direct URL). nosniff stops MIME confusion; the CSP sandbox blocks
+      // script execution and default-src 'none' blocks all resource loads.
+      // Inline <img> rendering in the inbox is unaffected — CSP on an image
+      // subresource is not applied to its rendering.
+      "X-Content-Type-Options": "nosniff",
+      "Content-Security-Policy": "default-src 'none'; sandbox"
     });
     res.end(buffer);
   });

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -39,6 +39,10 @@ test("POST /feedback stores valid feedback and saves screenshot data URLs", asyn
   assert.equal(screenshotResponse.status, 200);
   assert.match(screenshotResponse.headers.get("content-type"), /^image\/svg\+xml/);
   assert.equal(await screenshotResponse.text(), testSvg());
+  // An attacker-supplied SVG must not execute if opened directly: the serving
+  // response carries sandboxing headers (stored-XSS hardening, #44).
+  assert.equal(screenshotResponse.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(screenshotResponse.headers.get("content-security-policy"), "default-src 'none'; sandbox");
 });
 
 test("POST /feedback rejects malformed feedback payloads", async (t) => {


### PR DESCRIPTION
## 概要
保存 screenshot の配信に sandboxing ヘッダを付け、**SVG 格納型 XSS（監査 H-1）** を封じる。#44 の SVG XSS 部分（rate limit / ディスク上限 / ingest key は別 PR）。

## 背景
`handleGetScreenshot` は攻撃者制御の SVG を `image/svg+xml; charset=utf-8` で同一オリジン inline 配信し、CSP / `X-Content-Type-Options` を付けていなかった。`POST /feedback` は無認証なので任意 SVG を投稿でき、inbox の `<a target=_blank rel=noopener>`（`renderScreenshotPreview`）リンクや screenshot URL の直接オープンでトップレベル文書として解釈されると、receiver オリジン上で任意 JS が実行され得た（管理者狙いの stored XSS）。

## 変更
- `handleGetScreenshot` の 200 応答に付与:
  - `X-Content-Type-Options: nosniff`（MIME 推測の抑止）
  - `Content-Security-Policy: default-src 'none'; sandbox`（スクリプト実行と全リソース読込をブロック）
- インライン `<img>` 表示は不変（subresource として読まれる画像の描画に CSP は適用されない）。トップレベルで開いた場合のみ実行が封じられる。
- `/static` はアプリ第一者資産（inbox.js/css・widget.js）で、制限 CSP を当てると壊れるため**対象外**。inbox / static のヘッダは #43 の low ハードニングで別途。

## テスト
- `npm run check`（eslint + build --check + **77 tests**）green。
- 既存の screenshot 配信テストを拡張し、応答に `nosniff` と `default-src 'none'; sandbox` が付くことを assert。

## 補足（mitigation 選択の根拠）
- `nosniff` 単独では明示 `image/svg+xml` の実行は止まらないため CSP が本質。`Content-Disposition: attachment` 案は全 screenshot を強制 DL にし inline 閲覧を壊すため不採用。SVG 受理停止は widget のキャプチャ方式変更を伴うため別検討。CSP sandbox は UX を保ったまま実行のみ封じる最小策。
